### PR TITLE
Change tabs to spaces in CSS

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,49 +1,49 @@
 * {
-	font-family: Helvetica, sans-serif !important;
+  font-family: Helvetica, sans-serif !important;
 }
 
 body {
-	background: #F5F5F5;
+  background: #F5F5F5;
 }
 
 .top-bar-section li:not(.has-form) a:not(.button) {
-	line-height: 60px;
-	background: #FAE448;
+  line-height: 60px;
+  background: #FAE448;
 }
 
 .top-bar-section li.active:not(.has-form) a:not(.button) {
-	line-height: 60px;
-	background: #f5f5f5;
-	color: #111;
-	font-weight: 700;
+  line-height: 60px;
+  background: #f5f5f5;
+  color: #111;
+  font-weight: 700;
 }
 
 .top-bar-section li.active:not(.has-form) a:not(.button):hover, .top-bar-section li:not(.has-form) a:not(.button):hover {
-	background: #111;
-	color: white;
+  background: #111;
+  color: white;
 }
 
 .top-bar-section ul li>a {
-	color: #111;
-	text-transform: uppercase;
-	font-weight: 100;
-	font-size: 0.9rem;
+  color: #111;
+  text-transform: uppercase;
+  font-weight: 100;
+  font-size: 0.9rem;
 }
 
 .header {
-	background: #111;
-	color: white;
+  background: #111;
+  color: white;
   overflow: hidden;
   margin-bottom: 30px;
 }
 
 .header-content {
-	padding: 1.5rem;
-	overflow: hidden;
+  padding: 1.5rem;
+  overflow: hidden;
 }
 
 .header h1, h5 {
-	color: #fff;
+  color: #fff;
 }
 
 .size-12 { font-size: 12px; }      


### PR DESCRIPTION
There were inconsistent tabs vs. spaces in the CSS file. IMO we should use spaces for CSS just like we do for js.
