### PR TITLE
WIP: command-line interface

### DIFF
--- a/bin/Copay.js
+++ b/bin/Copay.js
@@ -1,0 +1,118 @@
+var imports = require('soop').imports();
+var PublicKeyRing = imports.PublicKeyRing || require('../js/models/core/PublicKeyRing');
+var Wallet = imports.Wallet || require('../js/models/core/Wallet');
+
+var Copay = function(opts) {
+  this._init(opts);
+};
+
+Copay.prototype._init = function(opts) {
+  var self = this;
+  
+  opts = opts ? opts : {};
+
+  self.optsList = [
+    'publicKeyRing',
+    'wallet'
+    ];
+
+  self.opts = {};
+  for (var a in self.optsList) {
+    if (opts.hasOwnProperty(a))
+      self.opts[a] = opts[a];
+  }
+  
+  self.publicKeyRing = self.opts.publicKeyRing ? self.opts.publicKeyRing : new PublicKeyRing();
+  self.wallet = self.opts.wallet ? self.opts.wallet : new Wallet();
+};
+
+Copay.prototype._command = function(command, args, callback) {
+  var self = this;
+  
+  if (command[0] == "_")
+    return callback(new Error('invalid command'));
+
+  if (typeof self[command] == 'function') {
+    var f = Copay.prototype[command];
+    if (f.argTypes[f.argTypes.length-1][1] == 'function')
+      return self[command].apply(self, args.concat([callback]));
+    else
+      return callback(null, self[command].apply(self, args));
+  };
+  
+  return callback(new Error('invalid command'));
+};
+
+Copay._checkArgTypes = function(command, args) {
+  var f = Copay.prototype[command];
+  for (var i in args) {
+    if (typeof args[i] != f.argTypes[i][1])
+      return false;
+  }
+  return true;
+};
+
+function checkArgs(name, args) {
+  if (!Copay._checkArgTypes(name, args))
+    throw new Error('Invalid arguments');
+}
+
+Copay.prototype.echo = function(str, callback) {
+  var self = this;
+  checkArgs('echo', arguments);
+
+  return callback(null, str);
+};
+
+Copay.prototype.echo.argTypes =
+  [
+  ['str', 'string'],
+  ['callback', 'function']
+  ];
+
+Copay.prototype.getBalance = function(callback) {
+  var self = this;
+  checkArgs('getBalance', arguments);
+
+  return callback(null, self.wallet.getBalance([]));
+};
+
+Copay.prototype.getBalance.argTypes =
+  [
+  ['callback', 'function']
+  ];
+
+Copay.prototype.getCommands = function(callback) {
+  var self = this;
+  checkArgs('getCommands', arguments);
+
+  var fs = [];
+
+  for (var i in Copay.prototype) {
+    var f = Copay.prototype[i];
+    if (typeof f == 'function' && i[0] != "_")
+      fs.push(i);
+  };
+
+  return callback(null, fs);
+};
+
+Copay.prototype.getCommands.argTypes =
+  [
+  ['callback', 'function']
+  ];
+
+Copay.prototype.getPublicKeyRingId = function(callback) {
+  var self = this;
+  checkArgs('getPublicKeyRingId', arguments);
+
+  return callback(null, self.publicKeyRing.id);
+};
+
+Copay.prototype.getPublicKeyRingId.argTypes =
+  [
+  ['callback', 'function']
+  ];
+
+
+module.exports = require('soop')(Copay);

--- a/bin/copay
+++ b/bin/copay
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+var Copay = require('./Copay.js');
+var commander = require('commander');
+
+var main = function() {
+
+  commander
+      .version("0.0.1")
+      .option('-f, --file [file]', 'AES encrypted data file', 'copay.json.aes')
+      .option('-p, --pass [passphrase]', 'AES wallet passphrase')
+      .option('-c, --client', 'Issue command over RPC to copay daemon')
+      .option('-d, --daemon', 'Run as daemon accepting RPC commands')
+      .option('--rpcport [port]', 'RPC port [18332]', Number, 18332)
+      .option('--rpcuser [user]', 'RPC user [user]', String, 'user')
+      .option('--rpcpass [password]', 'RPC password [pass]', String, 'pass')
+      .parse(process.argv);
+
+  var copay = new Copay(commander);
+
+  var args = commander.args;
+
+  copay._command(args[0], args.slice(1), function(err, result) {
+    if (err)
+      return console.log("" + err);
+    
+    console.log(JSON.stringify(result, null, 2));
+  });
+};
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
You can see commands by running "copay getCommands"

Types and arguments are enforced - right now only strings work. This is so that types can be
coerced from the command-line correctly. Number of arguments are also enforced.
In the future you will be able to pass in JSON objects as arguments and they
will be translated to real objects.

Examples:

```
> copay getCommands
[
  "echo",
  "getCommands",
  "getPublicKeyRingId"
]
> copay echo test
"test"
> copay getPublicKeyRingId
"23ae7bbf29bbfc92"

```

And if you use incorrect parameters:

```
ryanxcharles@rxc-h.local> ./bin/copay echo

/Users/ryanxcharles/dev/copay/bin/Copay.js:57
    throw new Error('Invalid arguments');
          ^
Error: Invalid arguments
    at checkArgs (/Users/ryanxcharles/dev/copay/bin/Copay.js:57:11)
    at Copay.echo (/Users/ryanxcharles/dev/copay/bin/Copay.js:62:3)
    at Copay._command (/Users/ryanxcharles/dev/copay/bin/Copay.js:38:28)
    at main (/Users/ryanxcharles/dev/copay/bin/copay:22:9)
    at Object.<anonymous> (/Users/ryanxcharles/dev/copay/bin/copay:31:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)

```

...in the future, errors will be handled more nicely.

The idea of this is that the same basic interface should also work for RPC so that we won't have to duplicate code. Soon, Copay.js will link directly to Wallet.js and not PublicKeyRing.js, and will just provide access to Wallet.js.
