### PR TITLE
lower font size of IDs so they fit in the boxes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -181,9 +181,14 @@ span.panel-res {
   margin: 0.5rem 0 1rem;
 }
 
+.panel.copayers {
+  font-size: 0.8em;
+}
+
 .share-wallet.panel {
   background-color: #111;
   color: #FBE500;
+  font-size: 0.8em;
 }
 
 .alert-box.warning, .alert-box.error {

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
 
 
           <ul class="no-bullet">
-            <li class="panel" ng-repeat="copayer in $root.wallet.network.connectedPeers">
+            <li class="panel copayers" ng-repeat="copayer in $root.wallet.network.connectedPeers">
               <span ng-if="copayer == $root.wallet.network.peerId"> You ({{copayer}})</span>
               <span ng-if="copayer !== $root.wallet.network.peerId">{{copayer}}</span>
               <span>


### PR DESCRIPTION
The copayer IDs were not fitting in the boxes. This lowers the font size slightly so they don't overflow the boxes.
