### PR TITLE
removed a updateBalance call from header.js

### DIFF
--- a/js/controllers/header.js
+++ b/js/controllers/header.js
@@ -27,7 +27,6 @@ angular.module('copay.header').controller('HeaderController',
     $rootScope.$watch('wallet', function(wallet) {
       if (wallet) {
         controllerUtils.setSocketHandlers();
-        controllerUtils.updateBalance();
       }
     });
 


### PR DESCRIPTION
This PR removes a call to the updateBalance method in order to avoid the several calls to $rooScope.$digest();
