### PR TITLE
added a zip file to download the webapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ lib/*
 
 js/copayBundle.js
 config.js
-gh-pages
+webapp
+

--- a/ghpages.sh
+++ b/ghpages.sh
@@ -3,8 +3,10 @@
 #Description: A simple script to compile and copy only the needed files for the web app.
 
 # Configs
-GHPDIR="gh-pages"
-LIBDIR="$GHPDIR/lib"
+APPDIR="webapp"
+LIBDIR="$APPDIR/lib"
+DOWNLOADDIR="$APPDIR/download"
+ZIPFILE="copay_webapp_.zip"
 
 OpenColor="\033["
 Red="1;31m"
@@ -14,11 +16,11 @@ CloseColor="\033[0m"
 
 # Create/Clean temp dir
 echo -e "${OpenColor}${Green}* Checking temp dir...${CloseColor}"
-if [ ! -d $GHPDIR ]; then
-  mkdir $GHPDIR
-else
-  rm -rf $GHPDIR/*
+if [ -d $APPDIR ]; then
+  rm -rf $APPDIR
 fi
+
+mkdir -p $APPDIR
 
 # Generate and copy bitcore bundle
 if [ ! -d node_modules/bitcore ]; then
@@ -37,8 +39,13 @@ grunt --target=dev shell
 
 # Copy all app files
 echo -e "${OpenColor}${Green}* Copying all app files...${CloseColor}"
-cp -af {css,font,img,js,lib,config.js,index.html} $GHPDIR
+cp -af {css,font,img,js,lib,config.js,index.html} $APPDIR
 cp -af node_modules/bitcore/browser/bundle.js $LIBDIR/
 mv $LIBDIR/bundle.js $LIBDIR/bitcore.js
 
-echo -e "${OpenColor}${Yellow}\nAwesome! You just need to copy and paste the ./gh-pages content to your local repository and push it.${CloseColor}"
+echo -e "${OpenColor}${Green}* Zipping all app files...${CloseColor}"
+zip -r $ZIPFILE $APPDIR
+mkdir -p $DOWNLOADDIR
+mv $ZIPFILE $DOWNLOADDIR
+
+echo -e "${OpenColor}${Yellow}\nAwesome! You just need to copy and paste the ./webapp content to your local repository and push it.${CloseColor}"


### PR DESCRIPTION
This PR includes a zip (copay_webapp.zip) file to download the webapp.

fixes https://github.com/bitpay/copay/issues/153
