### PR TITLE
Hiding flashes of unstyled content

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="css/foundation-icons.css">
     <link rel="stylesheet" href="css/main.css">
   </head>
-  <body>
+  <body ng-cloak class="ng-cloak">
     <div data-ng-init="init()" data-ng-controller="HeaderController">
       <div class="header"> 
         <div class="header-content">
@@ -93,7 +93,7 @@
 
   </div>
 
-  <div class="row" ng-cloak class="ng-cloak">
+  <div class="row">
     <div class="large-12 columns" ng-view></div>
   </div>
 


### PR DESCRIPTION
Do not show flashes like "{{variable}}" before render the first page. 
