### PR TITLE
fixed errors to import/open wallets

### DIFF
--- a/js/models/core/WalletFactory.js
+++ b/js/models/core/WalletFactory.js
@@ -53,9 +53,9 @@ WalletFactory.prototype._checkRead = function(walletId) {
 
 WalletFactory.prototype.fromObj = function(obj) {
   var opts = obj.opts;
-  opts['publicKeyRing'] = new PublicKeyRing.fromObj(obj.publicKeyRing);
-  opts['txProposals']   = new TxProposals.fromObj(obj.txProposals);
-  opts['privateKey']    = new PrivateKey.fromObj(obj.privateKey);
+  opts.publicKeyRing = new PublicKeyRing.fromObj(obj.publicKeyRing);
+  opts.txProposals   = new TxProposals.fromObj(obj.txProposals);
+  opts.privateKey    = new PrivateKey.fromObj(obj.privateKey);
   opts.storage = this.storage;
   opts.network = this.network;
   opts.blockchain = this.blockchain;


### PR DESCRIPTION
This PR includes a minimal fix for fromObj/read methods in order to import/open a wallet.
