### PR TITLE
fix config for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,11 @@ language: node_js
 node_js:
   - "0.10"
 
+notifications:
+  email: false
+
+branches:
+  only:
+  - master
+
 script: "mocha"


### PR DESCRIPTION
Travis CI is actually doing "git checkout" to another branch. Force it to use only "master"
