### PR TITLE
Allow NPM to Manage Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "bugs": {
     "url": "https://github.com/bitpay/copay/issues"
   },
+  "scripts": {
+    "test": "mocha"
+  },
   "homepage": "https://github.com/bitpay/copay",
   "devDependencies": {
     "express": "4.0.0",


### PR DESCRIPTION
This lets you execute `npm test` to run the tests.
