### PR TITLE
Fix concat.sh failure when building copay on Windows.

### DIFF
--- a/util/build.js
+++ b/util/build.js
@@ -30,7 +30,7 @@ var createBundle = function(opts) {
   opts.dir = opts.dir || 'js/';
 
   // concat browser vendor files
-  exec('cd ' + opts.dir + 'browser; sh concat.sh', puts);
+  exec('sh concat.sh', puts);
 
   var bopts = {
     pack: pack,


### PR DESCRIPTION
(and silent? bug in Linux builds - build.js attempts to cd to js/browser subdir, but there is no such directory in the copay project, and concat.sh resides in the project root)
