### PR TITLE
removed dropbox backup options

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,19 +557,13 @@
       <div class="backup" data-ng-controller="BackupController">
         <h3>{{title}}</h3>
         <div class="row text-center">
-          <div class="large-4 medium-4 columns">
+          <div class="large-3 medium-3 columns">
             <a class="panel box-backup" ng-click="download()">
               <i class="fi-download size-72"></i>
               <p> Download File </p>
             </a>
           </div>
-          <div class="large-4 medium-4 columns">
-            <a class="panel box-backup" ng-click="dropbox()">
-              <i class="fi-social-dropbox size-72"></i>
-              <p> Backup to Dropbox </p>
-            </a>
-          </div>
-          <div class="large-4 medium-4 columns">
+          <div class="large-3 medium-3 columns">
             <a class="panel box-backup" ng-click="email()">
               <i class="fi-mail size-72"></i>
               <p> Backup to email </p>

--- a/js/controllers/backup.js
+++ b/js/controllers/backup.js
@@ -4,31 +4,18 @@ angular.module('copay.backup').controller('BackupController',
   function($scope, $rootScope, $location, $window, $timeout) {
     $scope.title = 'Backup';
 
-    var filename = $rootScope.wallet.id + '.json.aes';
-
-    // TODO: get the real encrypted wallet.
     var _getEncryptedWallet = function() {
       var wallet = $rootScope.wallet.toEncryptedObj();
       return wallet;
     };
 
-    var _getWalletBlob = function() {
+    $scope.download = function() {
+      var timestamp = +(new Date);
+      var walletName = ($rootScope.wallet.name ? $rootScope.wallet.name : '') + '-' + $rootScope.wallet.id ;
+      var filename = walletName + '-' + timestamp + '.json.aes';
       var wallet = _getEncryptedWallet();
       var blob = new Blob([wallet], {type: 'text/plain;charset=utf-8'});
-
-      return blob;
-    };
-
-    $scope.download = function() {
-      var blob = _getWalletBlob();
       saveAs(blob, filename);
-    };
-
-    $scope.dropbox = function() { 
-      var blob = _getWalletBlob();
-      var url = $window.URL.createObjectURL(blob);
-
-      // TODO: send the blob to Dropbox, (if we can...)
     };
 
     $scope.email = function() {
@@ -40,9 +27,9 @@ angular.module('copay.backup').controller('BackupController',
       } else {
         if (email && email !== '') {
           var body = _getEncryptedWallet();
-          var subject = 'Copay Backup'; 
+          var subject = ($rootScope.wallet.name ? $rootScope.wallet.name + ' - ' : '') + $rootScope.wallet.id; 
           var href = 'mailto:' + email + '?'
-           + 'subject=' + subject + '&'
+           + 'subject=[Copay Backup] ' + subject + '&'
            + 'body=' + body;
 
           var newWin = $window.open(href, '_blank', 'scrollbars=yes,resizable=yes,width=10,height=10');


### PR DESCRIPTION
This PR removes the Dropbox backup option because doesnt work in 2 of 3 use cases. Just works when you run Copay in a public server. Not for file:// protocol or node local server.

fixes #148 
