### PR TITLE
improve language

### DIFF
--- a/js/controllers/transactions.js
+++ b/js/controllers/transactions.js
@@ -47,7 +47,7 @@ angular.module('copay.transactions').controller('TransactionsController',
       w.sendTx(ntxid, function(txid) {
           console.log('[transactions.js.68:txid:] SENTTX CALLBACK',txid); //TODO
           $rootScope.flashMessage = txid
-            ? {type:'success', message: 'Transactions SENT! txid:' + txid}
+            ? {type:'success', message: 'Transaction broadcasted. txid: ' + txid}
             : {type:'error', message: 'There was an error sending the Transaction'}
             ;
           _updateTxs();


### PR DESCRIPTION
Make the language of the transaction broadcasted message more professional, and add a space after "txid" so that you can easily copy+paste the txid.
