### PR TITLE
remove copayerID from UI

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -96,7 +96,6 @@ angular.module('copay.directives')
         var peerId = peer.peerId;
         var nick = peer.nick;
         element.addClass('video-small');
-        element.attr('title', peerId + (peerId == $rootScope.wallet.network.peerId ? ' (You)' : ''));
         var muted = $rootScope.getVideoMutedStatus(peerId);
         if (muted) {
           element.attr("muted", true);


### PR DESCRIPTION
I don't think it adds anything to the user, and we already have a tooltip for the nickname
