### PR TITLE
set smallest video resolution

### DIFF
--- a/js/services/video.js
+++ b/js/services/video.js
@@ -13,10 +13,18 @@ var Video = function() {
 Video.prototype.setOwnPeer = function(peer, wallet, cb) {
   var self = this;
 
-  navigator.getUserMedia({
+  var VWIDTH = 320;
+  var VHEIGHT = 320;
+  var constraints = {
     audio: true,
-    video: true
-  }, function(stream) {
+    video: {
+      mandatory: {
+        maxWidth: VWIDTH,
+        maxHeight: VHEIGHT,
+      }
+    }
+  };
+  navigator.getUserMedia(constraints, function(stream) {
     // This is called when user accepts using webcam
     self.localStream = stream;
     var online = wallet.getOnlinePeerIDs();


### PR DESCRIPTION
fixes https://github.com/bitpay/copay/issues/408

Note: Firefox doesn't support constraining resolutions for media streams. 
