### PR TITLE
hide qrcode scanner when file://

### DIFF
--- a/index.html
+++ b/index.html
@@ -559,10 +559,10 @@
                     <div class="small-10 columns">
                       <input type="text" id="address" name="address" placeholder="Send to" ng-model="address" valid-address required>
                     </div>
-                    <div class="small-2 columns" ng-hide="showScanner">
+                    <div class="small-2 columns" ng-hide="showScanner || !isHttp">
                       <a class="postfix button secondary" ng-click="openScanner()"><i class="fi-camera"></i></a>
                     </div>
-                    <div class="small-2 columns" ng-show="showScanner">
+                    <div class="small-2 columns" ng-show="showScanner && isHttp">
                       <a class="postfix button warning" ng-click="cancelScanner()">Cancel</a>
                     </div>
                   </div>

--- a/js/controllers/send.js
+++ b/js/controllers/send.js
@@ -28,10 +28,7 @@ angular.module('copay.send').controller('SendController',
     };
 
     // Detect protocol
-    $scope.isHttp = function() {
-      var protocol = $window.location.protocol;
-      return (protocol.indexOf('http') === 0);
-    };
+    $scope.isHttp = ($window.location.protocol.indexOf('http') === 0);
 
     navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
     window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;


### PR DESCRIPTION
This PR hides the QR code button when runs copay with file:// protocol, because the camera API isn't available.
fixes #454
