### PR TITLE
Add new peerjs server info to the default config

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -9,9 +9,9 @@ var defaultConfig = {
     //port: 10009,
     //path: '/',
     //
-    key: 'g23ihfh82h35rf', // api key for the peerjs server
-    host: '162.242.245.33', // peerjs server
-    port: 10009,
+    key: 'satoshirocks',    // api key for the peerjs server
+    host: '162.242.219.26', // peerjs server
+    port: 80,
     path: '/',
     maxPeers: 15,
     debug: 3,


### PR DESCRIPTION
The peerjs dedicated server has been successfully configured and tested for 10K concurrent connections.

Connected peers can be checked at http://162.242.219.26/stats

Closes #435
