### PR TITLE
Add warning message on new Copay version

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,15 @@
         
       </div>
 
+      <div class="row" ng-if="updateVersion">
+        <div class="small-9 large-centered columns">
+          <div data-alert class="alert-box radius {{updateVersion}}">
+            A newer version of Copay is now available, please update your wallet to a latest version.
+            Please check <a href="http://www.copay.io">Copay.io</a>.
+          </div>
+        </div>
+      </div>
+
       <div class="row" ng-if='$root.$flashMessage.message' notification>
         <div class="small-8 large-centered columns">
           <div data-alert class="alert-box radius {{$root.$flashMessage.type}}">

--- a/js/controllers/header.js
+++ b/js/controllers/header.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('copay.header').controller('HeaderController',
-  function($scope, $rootScope, $location, $notification, walletFactory, controllerUtils) {
+  function($scope, $rootScope, $location, $notification, $http, walletFactory, controllerUtils) {
     $scope.menu = [
     {
       'title': 'Addresses',
@@ -22,6 +22,18 @@ angular.module('copay.header').controller('HeaderController',
     }];
           
     var beep = new Audio('sound/transaction.mp3');
+
+    $http.get('https://api.github.com/repos/bitpay/copay/tags').success(function(data){
+      var toInt = function (s) { return parseInt(s); };
+      var latestVersion = data[0].name.replace('v', '').split('.').map(toInt);
+      var currentVersion = copay.version.split('.').map(toInt);
+
+      if (currentVersion[0] < latestVersion[0]){
+        $scope.updateVersion = 'error';
+      } else if (currentVersion[0] == latestVersion[0] && currentVersion[1] < latestVersion[1]) {
+        $scope.updateVersion = 'info';
+      }
+    });
 
     // Initialize alert notification (not show when init wallet)
     $rootScope.txAlertCount = 0;


### PR DESCRIPTION
We are using the last github tag for comparing the versions.

The alert shows only on major and minor miss match, making the message more clear on the first one. The message is fixed and can't be dismissed by the user, but still let them operate the wallet as usual.

VERSION = MAJOR.MINOR.XX

Closes #473

![screen shot 2014-06-02 at 16 55 47](https://cloud.githubusercontent.com/assets/279449/3152602/6425f890-ea90-11e3-9b30-2efacce9f0dc.png)
![screen shot 2014-06-02 at 16 57 05](https://cloud.githubusercontent.com/assets/279449/3152606/668306a0-ea90-11e3-941d-2f9a490bfca9.png)
