### PR TITLE
Handle error when importing a backup

### DIFF
--- a/js/controllers/import.js
+++ b/js/controllers/import.js
@@ -6,10 +6,15 @@ angular.module('copayApp.controllers').controller('ImportController',
     var reader = new FileReader();
     var _importBackup = function(encryptedObj) {
       Passphrase.getBase64Async($scope.password, function(passphrase){
-        var w = walletFactory.fromEncryptedObj(encryptedObj, passphrase);
+        var w, errMsg;
+        try {
+          w = walletFactory.fromEncryptedObj(encryptedObj, passphrase);
+        } catch(e) {
+          errMsg = e.message;
+        }
         if (!w) {
           $scope.loading = false;
-          $rootScope.$flashMessage = { message: 'Wrong password', type: 'error'};
+          $rootScope.$flashMessage = { message: errMsg || 'Wrong password', type: 'error'};
           $rootScope.$digest();
           return;
         }


### PR DESCRIPTION
On Import-backup page, If you write any text (not your valid encrypted wallet in plain text format) on input field, then you see "Importing wallet" instead to return an error.

Fixes #517
