### PR TITLE
mute videos by default

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -114,7 +114,7 @@ angular.module('copayApp.directives')
         var nick = peer.nick;
         element.addClass('video-small');
         var muted = controllerUtils.getVideoMutedStatus(peerId);
-        if (muted) {
+        if (true || muted) { // mute everyone for now
           element.attr("muted", true);
         }
       }


### PR DESCRIPTION
Video audio is having some problems in some browsers. This is a temporary solution (mute audio by default). In the future, we should implement video and audio controls in the UI.

fixes https://github.com/bitpay/copay/issues/579
