### PR TITLE
Python 2.6 is required for gyp

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ Default configuration can be found in the config.js file.
 See config.js for more info on configuration options.
 
 
+## Troubleshooting
+
+### Building on Ubuntu 14.04, gyp, Python
+
+  ```
+  gyp_main.py: error: no such option: --no-parallel
+  gyp ERR! configure error 
+  gyp ERR! stack Error: `gyp` failed with exit code: 2
+  ```
+
+Ubuntu 14.04 has Python 2.7, but gyp requires Python 2.6 (http://stackoverflow.com/questions/21155922/error-installing-node-gyp-on-ubuntu)
+
+One solution is to use Copay with a Python version manager for 2.6.
+
 # Development
 
 ## Google Chrome Extension


### PR DESCRIPTION
Document the problem (http://stackoverflow.com/questions/21155922/error-installing-node-gyp-on-ubuntu) and suggest a solution (use a Python version manager eg pyenv). This is especially helpful for Ubuntu 14.04 which comes with Python 2.7.
