### PR TITLE
fix copy/paste bug on osx/linux/win

### DIFF
--- a/js/shell.js
+++ b/js/shell.js
@@ -38,19 +38,9 @@
     var ipc   = require('ipc');
     var clipb = require('clipboard');
 
-    // atom shell forces to implement the clipboard on our own - thanks obama.
+    // atom shell forces to implement the clipboard (on osx) on our own - thanks obama.
 
     Mousetrap.stopCallback = function() { return false };
-
-    Mousetrap.bind('ctrl+c', function(e) {
-      clipb.writeText(window.getSelection().toString());
-    });
-
-    Mousetrap.bind('ctrl+v', function(e) {
-      if (document.activeElement) {
-        document.activeElement.value = clipb.readText();
-      }
-    });
 
     Mousetrap.bind('command+c', function(e) {
       clipb.writeText(window.getSelection().toString());
@@ -59,6 +49,7 @@
     Mousetrap.bind('command+v', function(e) {
       if (document.activeElement) {
         document.activeElement.value = clipb.readText();
+        document.activeElement.dispatchEvent(new Event('change'));
       }
     });
 


### PR DESCRIPTION
fixes failed validation on join wallet when pasting wallet secret.
- linux implements copy/paste for us, so it doubles the pasted content with the previous fix
- windows behaves normally irregardless (for once in it's existence)
- osx needs us to implement copy/paste on our own and needs us to fire a change event as well
