### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/bitpay/copay.png?label=ready&title=Ready)](https://waffle.io/bitpay/copay)
 # Copay
 [![Build Status](https://secure.travis-ci.org/bitpay/copay.png)](http://travis-ci.org/bitpay/copay)
 [![Coverage Status](https://coveralls.io/repos/bitpay/copay/badge.png?branch=)](https://coveralls.io/r/bitpay/copay?branch=)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/bitpay/copay

This was requested by a real person (user matiu) on waffle.io, we're not trying to spam you.
