### PR TITLE
remove console.log from test

### DIFF
--- a/test/test.WalletFactory.js
+++ b/test/test.WalletFactory.js
@@ -49,10 +49,13 @@ describe('WalletFactory model', function() {
     var c2 = JSON.parse(JSON.stringify(config));
     c2.verbose = 1;
     var wf = new WalletFactory(c2, '0.0.1');
+    var save_console_log = console.log;
+    console.log = function() {};
     var spy = sinon.spy(console, 'log');
     wf.log('ok');
     sinon.assert.callCount(spy, 1);
     spy.getCall(0).args[0].should.equal('ok');
+    console.log = save_console_log;
   });
 
 


### PR DESCRIPTION
...cluttering the console.log output can be avoided using methods like this. Note that this method is dangerous in the sense that you obviously must remember to replace console.log with the saved value otherwise you will get mysterious errors.

mocha node and mocha browser tests pass. (karma tests don't pass for reasons having nothing to do with this PR - the broken karma tests were introduced in https://github.com/bitpay/copay/pull/688 )
