### PR TITLE
remove console.log in test

### DIFF
--- a/test/test.blockchain.Insight.js
+++ b/test/test.blockchain.Insight.js
@@ -133,7 +133,6 @@ describe('Insight model', function() {
     };
 
     w.checkActivity(addresses, function(err, actives) {
-      console.log(err);
       actives.length.should.equal(addresses.length);
       actives.filter(function(i) {
         return i


### PR DESCRIPTION
Please don't put console.logs in tests. All tests pass: mocha node, mocha browser, karma.
