### PR TITLE
fix exception in insight mocha browser tests

### DIFF
--- a/test/test.blockchain.Insight.js
+++ b/test/test.blockchain.Insight.js
@@ -60,7 +60,7 @@ describe('Insight model', function() {
   });
 
   // Tests for Node
-  if (process.version) {
+  if (typeof process !== 'undefined' && process.version) {
     it('should return array of unspent output', function(done) {
       var i = new Insight();
 


### PR DESCRIPTION
The Insight tests were actually broken and not running due to trying to access the nonexistent process variable. You could see the exception in the browser console. The proper way to check for this is to see if its type is undefined before trying to access it.
