### PR TITLE
Disable node-integration in atom-shell browser environment

### DIFF
--- a/shell/index.js
+++ b/shell/index.js
@@ -24,7 +24,8 @@ module.exports = function(copay) {
       // create the main window
       mainWindow = new BrowserWindow({
         width: config.window.width,
-        height: config.window.height
+        height: config.window.height,
+        "node-integration": "disable"
       });
 
       // hide the empty window
@@ -52,7 +53,7 @@ module.exports = function(copay) {
         mainWindow = null;
       });
 
-      // mainWindow.toggleDevTools();
+      //mainWindow.toggleDevTools();
 
     });
 


### PR DESCRIPTION
Node integration causes problems because it makes the loader environment different than what we have in the webapp.  By disabling it, we keep the loading environment the same (and eliminates problems).
