### PR TITLE
fix mocha node tests / update to bitcore v0.1.25

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "sjcl": "1.0.0",
     "file-saver": "*",
     "qrcode-decoder-js": "*",
-    "bitcore": "0.1.24",
+    "bitcore": "0.1.25",
     "angular-moment": "~0.7.1",
     "socket.io-client": ">=1.0.0",
     "mousetrap": "1.4.6"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/bitpay/copay",
   "devDependencies": {
     "async": "0.9.0",
-    "bitcore": "0.1.24",
+    "bitcore": "0.1.25",
     "blanket": "1.1.6",
     "browser-pack": "2.0.1",
     "browserify": "3.32.1",

--- a/test/test.Wallet.js
+++ b/test/test.Wallet.js
@@ -595,7 +595,7 @@ describe('Wallet model', function() {
     }];
     var addr = w.generateAddress().toString();
     utxo[0].address = addr;
-    utxo[0].scriptPubKey = TransactionBuilder.scriptForAddress(addr).serialize().toString('hex');
+    utxo[0].scriptPubKey = (new bitcore.Address(addr)).getScriptPubKey().serialize().toString('hex');
     return utxo;
   };
   var toAddress = 'mjfAe7YrzFujFf8ub5aUrCaN5GfSABdqjh';


### PR DESCRIPTION
There was a weird problem with bitcore 0.1.24. Somehow, the npm version and bower versions were not the same. In the mocha node tests, if you installed Copay from scratch, you would see that the Wallet test was trying to use the scriptForAddress function, which has moved to address.getAddressPubKey. However, that change did not exist in the bower package (even though both npm and bower were at 0.1.24). It's possible in the last time I published to npm, I used the wrong commit. I have fixed this by updating both the npm and bower packages to 0.1.25, and also updating copay to use the new 0.1.25.

On Copay master, the mocha tests are broken (which you will notice if you do a clean install), but the mocha browser tests work. With this PR, they both work.
