### PR TITLE
Alternate Strategy to Fix MomentJS Loading as Node Module When we want it as Global

### DIFF
--- a/index.html
+++ b/index.html
@@ -919,6 +919,9 @@ on supported browsers please check <a href="http://www.webrtc.org/">http://www.w
     </script>
 
     <script src="lib/mousetrap/mousetrap.min.js"></script>
+    <!-- shell must be loaded before moment due to the way moment loads in a commonjs env -->
+    <script src="js/shell.js"></script>
+
     <script src="lib/angular/angular.min.js"></script>
     <script src="lib/moment/min/moment.min.js"></script>
     <script src="lib/angular-moment/angular-moment.js"></script>
@@ -939,7 +942,6 @@ on supported browsers please check <a href="http://www.webrtc.org/">http://www.w
     <script src="lib/qrcode-decoder-js/lib/qrcode-decoder.min.js"></script>
 
     <script src="config.js"></script>
-    <script src="js/shell.js"></script>
     <script src="js/copayBundle.js"></script>
     <script src="js/app.js"></script>
     <script src="js/routes.js"></script>

--- a/js/shell.js
+++ b/js/shell.js
@@ -12,7 +12,7 @@
    ** the renderer into thinking that we are _not_ in a CommonJS environment.
    */
   if (typeof module !== 'undefined') module = {
-    exports: null
+    exports: false
   };
 
   // are we running in copay shell?

--- a/shell/index.js
+++ b/shell/index.js
@@ -24,8 +24,7 @@ module.exports = function(copay) {
       // create the main window
       mainWindow = new BrowserWindow({
         width: config.window.width,
-        height: config.window.height,
-        "node-integration": "disable"
+        height: config.window.height
       });
 
       // hide the empty window


### PR DESCRIPTION
My change to disable node-integration in the shell renderer fixed the moment loading problem, but broke a bunch of other things that depended on node integration (almost all backend node stuff, like downloading keys, etc).

This request reverses the prior change as well as uses a different strategy to correct the problems with momentjs in commonjs environment.
