### PR TITLE
workaround bug of urihandler in firefox

### DIFF
--- a/js/services/uriHandler.js
+++ b/js/services/uriHandler.js
@@ -5,8 +5,7 @@ var UriHandler = function() {};
 UriHandler.prototype.register = function() {
   var base = window.location.origin + '/';
   var url = base + '#/uri_payment/%s';
-  navigator.registerProtocolHandler('bitcoin',
-    url, 'Copay');
+  // navigator.registerProtocolHandler('bitcoin', url, 'Copay');
 };
 
 angular.module('copayApp.services').value('uriHandler', new UriHandler());


### PR DESCRIPTION
this line was creating the error: 

```
NS_ERROR_XPC_JS_THREW_STRING: Permission denied to add file:///Users/ematiu/devel/node/copay/null/#/uri_payment/%s as a content or protocol handler'Permission denied to add file:///Users/ematiu/devel/node/copay/null/#/uri_payment/%s as a content or protocol handler' when calling method: [nsIWebContentHandlerRegistrar::registerProtocolHandler]'
```

which prevent firefox to join wallets. This PR temporary disables uriHandler.
