### PR TITLE
Fix angular version to 1.2.16

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "multisignature"
   ],
   "dependencies": {
-    "angular": "=1.2.16", // our coustom noFractionNumber filter is not compatible with higher versions.
+    "angular": "=1.2.19",
     "angular-foundation": "*",
     "angular-route": "~1.2.14",
     "angular-qrcode": "~3.1.0",


### PR DESCRIPTION
The noFractionNumber filter uses the angular's number filter. There was a change in its behaviour between versions 1.2.16 and 1.2.18.

Test:
var numberFilter = angular.element($('#main')).injector().get('numberFilter'); // load angular filter

numberFilter(0, 8) // returns "0.00000000" on 1.2.16
numberFilter(0, 8) // returns "5,e-9.00000000" on 1.2.18

Updating or replacing the noFractionNumber filter is left to be done in other issue, if necessary.

Fixes #791 #889 
