### PR TITLE
Add a pre-generated address to the shared branch

### DIFF
--- a/js/models/core/HDParams.js
+++ b/js/models/core/HDParams.js
@@ -18,7 +18,7 @@ function HDParams(opts) {
 
 HDParams.init = function(totalCopayers) {
   preconditions.shouldBeNumber(totalCopayers);
-  var ret = [new HDParams()];
+  var ret = [new HDParams({receiveIndex: 1})];
   for (var i = 0 ; i < totalCopayers ; i++) {
     ret.push(new HDParams({copayerIndex: i}));
   }

--- a/js/services/controllerUtils.js
+++ b/js/services/controllerUtils.js
@@ -185,13 +185,14 @@ angular.module('copayApp.services')
 
     root.updateAddressList = function() {
       var w = $rootScope.wallet;
-      if (w)
+      if (w && w.isReady())
         $rootScope.addrInfos = w.getAddressesInfo();
     };
 
     root.updateBalance = function(cb) {
       var w = $rootScope.wallet;
       if (!w) return root.onErrorDigest();
+      if (!w.isReady()) return;
 
       $rootScope.balanceByAddr = {};
       $rootScope.updatingBalance = true;

--- a/test/mocks/FakeWallet.js
+++ b/test/mocks/FakeWallet.js
@@ -46,6 +46,10 @@ FakeWallet.prototype.getAddressesInfo = function() {
   return ret;
 };
 
+FakeWallet.prototype.isReady = function() {
+  return true;
+}
+
 
 FakeWallet.prototype.getBalance = function(cb) {
   return cb(null, this.balance, this.balanceByAddr, this.safeBalance);

--- a/test/test.PublicKeyRing.js
+++ b/test/test.PublicKeyRing.js
@@ -145,9 +145,8 @@ describe('PublicKeyRing model', function() {
     var k = createW();
     var w = k.w;
 
-
     var a = w.getAddresses();
-    a.length.should.equal(0);
+    a.length.should.equal(1);
 
     [true, false].forEach(function(isChange){
       for (var i = 0; i < 2; i++) {
@@ -156,13 +155,20 @@ describe('PublicKeyRing model', function() {
     });
 
     var as = w.getAddressesInfo();
-    as.length.should.equal(4);
+    as.length.should.equal(5); // include pre-generated shared one
     for (var j in as) {
       var a = as[j];
       a.address.isValid().should.equal(true);
       a.addressStr.should.equal(a.address.toString());
-      a.isChange.should.equal([false, false, true, true][j]);
+      a.isChange.should.equal([false, false, false, true, true][j]);
     }
+  });
+
+
+  it('should start with one shared address', function() {
+    var k = createW();
+    var a = k.w.getAddresses();
+    a.length.should.equal(1);
   });
 
   it('should count generation indexes', function() {

--- a/test/test.Wallet.js
+++ b/test/test.Wallet.js
@@ -594,7 +594,7 @@ describe('Wallet model', function() {
 
 
   it('should get balance', function(done) {
-    var w = createW();
+    var w = createW2();
     var spy = sinon.spy(w.blockchain, 'getUnspent');
     w.blockchain.fixUnspent([]);
     w.getBalance(function(err, balance, balanceByAddr, safeBalance) {


### PR DESCRIPTION
Now wallets starts with a pre generated address on the shared branch. This way when every copayer open the first time the wallet they will find an address instead of an empty list.

Shared branch rationale:
- It's too complicated to agree in one copayer to create the first address and work properly in an asynchronous way. This solution may involve managing the concept of "wallet creator".
- We have it and using it make sense.

Closes #967
