### PR TITLE
Bitcore version - use v0.1.35

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "sjcl": "1.0.0",
     "file-saver": "*",
     "qrcode-decoder-js": "*",
-    "bitcore": "git://github.com/bitpay/bitcore.git#master",
+    "bitcore": "0.1.35",
     "angular-moment": "~0.7.1",
     "socket.io-client": ">=1.0.0",
     "mousetrap": "1.4.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "github-releases": "0.2.0",
     "grunt-markdown": "0.5.0",
     "browser-pack": "2.0.1",
-    "bitcore": "git://github.com/bitpay/bitcore.git#master",
+    "bitcore": "0.1.35",
     "node-cryptojs-aes": "0.4.0",
     "blanket": "1.1.6",
     "express": "4.0.0",


### PR DESCRIPTION
This will expose RootCerts to the payment protocol implementation.
