### PR TITLE
Travis: "grunt --targer=dev shell" is obsolete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - npm install
   - bower install
 before_script:
-  - grunt shell --target=dev
+  - grunt
 notifications:
   hipchat:
     rooms:


### PR DESCRIPTION
Just "grunt" for development and "grunt prod" for production environments.
