### PR TITLE
If transaction proposal was sent, remove "loading icon"

### DIFF
--- a/views/includes/transaction.html
+++ b/views/includes/transaction.html
@@ -54,7 +54,7 @@
           <i class="fi-check icon-status icon-active-check"></i>
       </a>
 
-      <a ng-if="!c.actions.sign && !c.actions.rejected" class="icon-status">
+      <a ng-if="!c.actions.sign && !c.actions.rejected && tx.missingSignatures" class="icon-status">
           <i class="fi-loop icon-rotate"></i>
       </a>
     </div>


### PR DESCRIPTION
Fixes #1143 

If a transaction proposal was sent, I removed "loading icon" from other copayers that didn't sign it.
