### PR TITLE
Fixes angular issue

### DIFF
--- a/js/services/controllerUtils.js
+++ b/js/services/controllerUtils.js
@@ -48,7 +48,6 @@ angular.module('copayApp.services')
       if (msg) {
         notification.error('Error', msg);
       }
-//      $rootScope.$digest();
     };
 
     root.installStartupHandlers = function(wallet, $scope) {


### PR DESCRIPTION
When closing a wallet that was opened in another window.

```
## DISCONNECTING copayBundle.js:2023
Error: [$rootScope:inprog] http://errors.angularjs.org/1.2.21/$rootScope/inprog?p0=%24digest
```

Fixes #1126 

Note: I tested with many errors to check if this commented line affect another behavior. It seems to work fine. If you consider it 's OK, I will remove the commented line.
