### PR TITLE
Only check for new version once

### DIFF
--- a/js/controllers/version.js
+++ b/js/controllers/version.js
@@ -1,28 +1,33 @@
 'use strict';
 
-angular.module('copayApp.controllers').controller('VersionController', 
-    function($scope, $rootScope, $http, notification) {
+angular.module('copayApp.controllers').controller('VersionController',
+  function($scope, $rootScope, $http, notification) {
 
     $scope.version = copay.version;
     $scope.commitHash = copay.commitHash;
     $scope.networkName = config.networkName;
     $scope.defaultLanguage = config.defaultLanguage;
+    if (_.isUndefined($rootScope.checkVersion))
+      $rootScope.checkVersion = true;
 
-    $http.get('https://api.github.com/repos/bitpay/copay/tags').success(function(data) {
-      var toInt = function(s) {
-        return parseInt(s);
-      };
-      var latestVersion = data[0].name.replace('v', '').split('.').map(toInt);
-      var currentVersion = copay.version.split('.').map(toInt);
-      var title = 'Copay ' + data[0].name + ' available.';
-      var content;
-      if (currentVersion[0] < latestVersion[0]) {
-        content = 'It\'s important that you update your wallet at https://copay.io';
-        notification.version(title, content, true);
-      } else if (currentVersion[0] == latestVersion[0] && currentVersion[1] < latestVersion[1]) {
-        var content = 'Please update your wallet at https://copay.io';
-        notification.version(title, content, false);
-      }
-    });
+    if ($rootScope.checkVersion) {
+      $rootScope.checkVersion = false;
+      $http.get('https://api.github.com/repos/bitpay/copay/tags').success(function(data) {
+        var toInt = function(s) {
+          return parseInt(s);
+        };
+        var latestVersion = data[0].name.replace('v', '').split('.').map(toInt);
+        var currentVersion = copay.version.split('.').map(toInt);
+        var title = 'Copay ' + data[0].name + ' available.';
+        var content;
+        if (currentVersion[0] < latestVersion[0]) {
+          content = 'It\'s important that you update your wallet at https://copay.io';
+          notification.version(title, content, true);
+        } else if (currentVersion[0] == latestVersion[0] && currentVersion[1] < latestVersion[1]) {
+          var content = 'Please update your wallet at https://copay.io';
+          notification.version(title, content, false);
+        }
+      });
+    }
 
   });


### PR DESCRIPTION
There were multiple notifications for a new version of Copay. I think it is enough if we show this notification once in the home screen.
Fixes #1348
Fixes #1349
