### PR TITLE
When only 1 signature is required, broadcast at creation

### DIFF
--- a/js/controllers/send.js
+++ b/js/controllers/send.js
@@ -142,7 +142,7 @@ angular.module('copayApp.controllers').controller('SendController',
           });
         }
 
-        if (w.isShared()) {
+        if (w.requiresMultipleSignatures()) {
           $scope.loading = false;
           var message = 'The transaction proposal has been created';
           if (merchantData) {

--- a/js/models/Wallet.js
+++ b/js/models/Wallet.js
@@ -2476,6 +2476,14 @@ Wallet.prototype.isShared = function() {
 };
 
 /**
+ * @desc Returns true if more than one signature is required
+ * @return {boolean}
+ */
+Wallet.prototype.requiresMultipleSignatures = function() {
+  return this.requiredCopayers > 1;
+};
+
+/**
  * @desc Returns true if the keyring is complete and all users have backed up the wallet
  * @return {boolean}
  */

--- a/test/mocks/FakeWallet.js
+++ b/test/mocks/FakeWallet.js
@@ -95,6 +95,10 @@ FakeWallet.prototype.isShared = function() {
   return this.totalCopayers > 1;
 }
 
+FakeWallet.prototype.requiresMultipleSignatures = function() {
+  return this.requiredCopayers > 1;
+};
+
 FakeWallet.prototype.isReady = function() {
   return true;
 };


### PR DESCRIPTION
On 1-n wallets, when a copayer creates a transaction it should be broadcast on the spot.
