### PR TITLE
add secret to adv options in #more

### DIFF
--- a/js/controllers/more.js
+++ b/js/controllers/more.js
@@ -64,8 +64,11 @@ angular.module('copayApp.controllers').controller('MoreController',
 
     $scope.hideAdv = true;
     $scope.hidePriv = true;
-    if (w)
+    $scope.hideSecret = true;
+    if (w) {
       $scope.priv = w.privateKey.toObj().extendedPrivateKeyString;
+      $scope.secret = w.getSecret();
+    }
 
     $scope.downloadBackup = function() {
       backupService.download(w);

--- a/js/models/Wallet.js
+++ b/js/models/Wallet.js
@@ -524,6 +524,7 @@ Wallet.prototype._onData = function(senderId, data, ts) {
   log.debug('RECV', senderId, data);
 
   if (data.type !== 'walletId' && this.id !== data.walletId) {
+    log.debug('Received corrupt message:', data)
     this.emit('corrupt', senderId);
     this.updateTimestamp(ts);
     return;

--- a/js/models/WalletFactory.js
+++ b/js/models/WalletFactory.js
@@ -451,7 +451,7 @@ WalletFactory.prototype.joinCreateSession = function(opts, cb) {
   };
 
   if (opts.privateHex && opts.privateHex.length > 1) {
-    privOpts.extendedPrivateKeyString = privateHex;
+    privOpts.extendedPrivateKeyString = opts.privateHex;
   }
 
   //Create our PrivateK

--- a/test/mocks/FakeWallet.js
+++ b/test/mocks/FakeWallet.js
@@ -59,6 +59,11 @@ FakeWallet.prototype.createTx = function(toAddress, amountSatStr, comment, opts,
   callback(null, {});
 }
 
+
+FakeWallet.prototype.getSecret = function() {
+  return 'xxx';
+};
+
 FakeWallet.prototype.sendTx = function(ntxid, cb) {
   cb(8);
 }

--- a/views/more.html
+++ b/views/more.html
@@ -87,6 +87,21 @@
           </a>
         </div>
     </div>
+    <div class="oh large-12 columns panel">
+      <h3><i class="fi-minus-circle m10r"></i> 
+      <span translate>Join Secret</span> </h3>
+      <p translate class="large-8 columns text-gray">
+        This is the initial secret join string. Since your wallet it is already complete, this is only useful to rejoin peers that loose their backup BUT have the extented private key stored (they will be rejected on other case). They need to enter their extended private key during the join process (in advenced options).
+      </p>
+      <div class="large-4 columns">
+        <a class="button primary expand" ng-click="hideSecret=!hideSecret">
+          <span translate ng-hide="!hideSecret">Show</span>
+          <span translate ng-hide="hideSecret">Hide</span>
+        </a>
+      </div>
+      <textarea ng-hide="hideSecret" readonly>{{secret}}</textarea>
+    </div>
+ 
   </div>
 
 </div>


### PR DESCRIPTION
This simple PR adds the possibility of showing the secret connection string in #more -> advances, to address (partially) https://github.com/bitpay/copay/issues/1527
