### PR TITLE
add --debugjs (don´t uglify the js) option to cordova/build.sh for easie...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -238,6 +238,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', ['shell:dev', 'nggettext_compile', 'concat', 'cssmin']);
   grunt.registerTask('dist', ['shell:prod', 'nggettext_compile', 'concat', 'cssmin', 'uglify', 'copy:dist']);
+  grunt.registerTask('dist-dbg', ['shell:dev', 'nggettext_compile', 'concat', 'cssmin', 'copy:dist']);
   grunt.registerTask('prod', ['shell:prod', 'nggettext_compile', 'concat', 'cssmin', 'uglify']);
   grunt.registerTask('translate', ['nggettext_extract']);
   grunt.registerTask('docs', ['jsdoc']);

--- a/cordova/build.sh
+++ b/cordova/build.sh
@@ -24,16 +24,22 @@ VERSION=`cut -d '"' -f2 $BUILDDIR/../version.js`
 
 SKIPIOS=false
 CLEAR=false
+DBGJS=false
 
 # Check Args
-if [[ $1 = "--android" || $2 = "--android" ]]
+if [[ $1 = "--android" || $2 = "--android" || $3 = "--android" ]]
 then
   SKIPIOS=true
 fi
 
-if [[ $1 = "--clear" || $2 = "--clear" ]]
+if [[ $1 = "--clear" || $2 = "--clear" || $3 = "--clear" ]]
 then
   CLEAR=true
+fi
+
+if [[ $1 = "--dbgjs" || $2 = "--dbgjs" || $3 = "--dbgjs" ]]
+then
+  DBGJS=true
 fi
 
 
@@ -88,10 +94,18 @@ if [ ! -d $PROJECT ]; then
 
 fi
 
-echo "${OpenColor}${Green}* Generating copay bundle...${CloseColor}"
-cd $BUILDDIR/..
-grunt dist
-checkOK
+if $DBGJS
+then
+  echo "${OpenColor}${Green}* Generating copay bundle (debug js)...${CloseColor}"
+  cd $BUILDDIR/..
+  grunt dist-dbg
+  checkOK
+else
+  echo "${OpenColor}${Green}* Generating copay bundle...${CloseColor}"
+  cd $BUILDDIR/..
+  grunt dist
+  checkOK
+fi
 
 echo "${OpenColor}${Green}* Coping files...${CloseColor}"
 cd $BUILDDIR/..


### PR DESCRIPTION
...r remote debugging.

added dist-dbg to grunt which is nearly the same as dist but uses shell:dev instead and doesn´t uglify the JS.
Added --dbgjs to cordova/build.sh which calls dist-dbg instead of dist when used as i am debugging the js remote on the phone via chrome webview debugger and uglified js is pretty pointless for that.
