### PR TITLE
Revert "fix(webpack): no obfuscate function for dev env"

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -98,6 +98,44 @@ var devConfig = {
       systemvars: true, // load all the predefined 'process.env' variables which will trump anything local per dotenv specs.
       silent: true // hide any errors
     }),
+    new JavaScriptObfuscator(
+      {
+        compact: true,
+        controlFlowFlattening: false,
+        deadCodeInjection: false,
+        debugProtection: false,
+        debugProtectionInterval: false,
+        disableConsoleOutput: false,
+        identifierNamesGenerator: 'hexadecimal',
+        log: false,
+        numbersToExpressions: false,
+        renameGlobals: false,
+        rotateStringArray: true,
+        selfDefending: false,
+        shuffleStringArray: true,
+        simplify: true,
+        splitStrings: false,
+        stringArray: true,
+        stringArrayEncoding: true,
+        stringArrayWrappersCount: 1,
+        stringArrayWrappersChainedCalls: true,
+        stringArrayWrappersType: 'variable',
+        stringArrayThreshold: 0.75,
+        unicodeEscapeSequence: false
+      },
+      [
+        '0.js',
+        '1.js',
+        '2.js',
+        '3.js',
+        '4.js',
+        '5.js',
+        '6.js',
+        '7.js',
+        'vendor.js',
+        'polyfills.js'
+      ]
+    ),
     ionicWebpackFactory.getIonicEnvironmentPlugin(),
     ionicWebpackFactory.getCommonChunksPlugin(),
     new ModuleConcatPlugin()


### PR DESCRIPTION
This commit breaks the official android release compilation, using the 'npm run final:android' command. It complains about 'javascript-obfuscator' missing. Reverting this commit allows the build to finish.

This reverts commit 93553387c775ba78fd4111458a97cb895a5597f6.