### PR TITLE
Feat: add DAI and WBTC support to Wyre

### DIFF
--- a/src/components/info-sheet/info-sheet.html
+++ b/src/components/info-sheet/info-sheet.html
@@ -428,8 +428,6 @@
       <span sheet-title-text translate>Payment Error</span>
       <span sheet-text>
         <span translate>There was an error with the payment process through Wyre.</span>
-        <br>
-        <span translate>You can describe the problem to Wyre's support team: support@sendwyre.com</span>
       </span>
       <span sheet-button-text translate>Visit Help Center</span>
       <span sheet-second-button-text translate>GOT IT</span>

--- a/src/pages/buy-crypto/crypto-offers/crypto-offers.ts
+++ b/src/pages/buy-crypto/crypto-offers/crypto-offers.ts
@@ -361,7 +361,10 @@ export class CryptoOffersPage {
             if (data.message && _.isString(data.message)) {
               this.logger.error(data.message);
             }
-            const err = this.translate.instant(
+            if (data.error && _.isString(data.error)) {
+              this.logger.error(data.error);
+            }
+            let err = this.translate.instant(
               "Can't get rates at this moment. Please try again later"
             );
             this.showSimplexError(err);

--- a/src/pages/integrations/wyre/wyre.html
+++ b/src/pages/integrations/wyre/wyre.html
@@ -47,11 +47,9 @@
   <ion-toolbar>
     <div class="wyre-problems">
       <span translate>Having problems with Wyre?</span>
-      <a (click)="openExternalLink('https://support.sendwyre.com/')" translate>
+      <a (click)="openExternalLink('https://wyre-support.zendesk.com/hc/en-us/requests/new')" translate>
         Visit Help Center
       </a>
-      <br>
-      <span translate>Or contact Wyre's support team: support@sendwyre.com</span>
     </div>
   </ion-toolbar>
 </ion-footer>

--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -455,6 +455,8 @@ export class AmountPage {
         ? '= ' + this.processResult(result)
         : '';
 
+      if (this.fromBuyCrypto) return;
+
       if (this.availableUnits[this.unitIndex].isFiat) {
         let a = this.fromFiat(result);
         if (a) {

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -729,7 +729,9 @@ export class IncomingDataProvider {
       infoSheet.present();
       infoSheet.onDidDismiss(option => {
         if (option) {
-          this.openExternalLink('https://support.sendwyre.com/');
+          this.openExternalLink(
+            'https://wyre-support.zendesk.com/hc/en-us/requests/new'
+          );
         }
       });
       return;

--- a/src/providers/wyre/wyre.ts
+++ b/src/providers/wyre/wyre.ts
@@ -30,7 +30,7 @@ export class WyreProvider {
     this.logger.debug('WyreProvider initialized - env: ' + this.env);
     this.uri = env.name == 'development' ? URI_DEV : URI_PROD;
     this.supportedFiatAltCurrencies = ['AUD', 'CAD', 'EUR', 'GBP', 'USD'];
-    this.supportedCoins = ['btc', 'eth', 'usdc', 'gusd', 'pax', 'busd'];
+    this.supportedCoins = ['btc', 'eth', 'usdc', 'gusd', 'pax', 'busd', 'dai'];
     this.fiatAmountLimits = {
       min: 1,
       max: 1000

--- a/src/providers/wyre/wyre.ts
+++ b/src/providers/wyre/wyre.ts
@@ -30,7 +30,16 @@ export class WyreProvider {
     this.logger.debug('WyreProvider initialized - env: ' + this.env);
     this.uri = env.name == 'development' ? URI_DEV : URI_PROD;
     this.supportedFiatAltCurrencies = ['AUD', 'CAD', 'EUR', 'GBP', 'USD'];
-    this.supportedCoins = ['btc', 'eth', 'usdc', 'gusd', 'pax', 'busd', 'dai'];
+    this.supportedCoins = [
+      'btc',
+      'eth',
+      'usdc',
+      'gusd',
+      'pax',
+      'busd',
+      'dai',
+      'wbtc'
+    ];
     this.fiatAmountLimits = {
       min: 1,
       max: 1000


### PR DESCRIPTION
- Adds DAI and WBTC support to Wyre

I also tested USDC, DAI (crypto) and IDR, SAR (Fiat) that are listed as supported on the Simplex website. But they don't seem to work. That's why I didn't add them.

- Wyre's support url updated. At their request, I have removed their contact email.
- This PR also fixes an error that disable continue button in amount page when select an uncommon fiat currency
- Adds a log for certain errors in requests to Simplex

