### PR TITLE
fix(wallets-tab): update balance for new wallets when receiving funds

### DIFF
--- a/src/components/wallet-item-content/wallet-item-content.html
+++ b/src/components/wallet-item-content/wallet-item-content.html
@@ -11,18 +11,12 @@
   </ion-label>
   <ion-note item-end>
     <div>
-      <div *ngIf="!hasZeroBalance(wallet, wallet?.coin.toUpperCase()) && !wallet?.balanceHidden">
+      <div *ngIf="!wallet?.balanceHidden">
         <div class="main-note">{{ getBalance(wallet, wallet?.coin.toUpperCase()) }}</div>
         <div class="secondary-note" *ngIf="wallet?.cachedStatus">
           {{ getAlternativeBalance(wallet, wallet?.coin.toUpperCase()) }}
           {{ wallet?.cachedStatus.alternativeIsoCode }}
         </div>
-      </div>
-    </div>
-    <div *ngIf="hasZeroBalance(wallet, wallet?.coin.toUpperCase()) && !wallet?.balanceHidden">
-      <div class="main-note">0</div>
-      <div class="secondary-note" *ngIf="wallet?.cachedStatus">
-        0 {{ wallet?.cachedStatus.alternativeIsoCode }}
       </div>
     </div>
     <div *ngIf="wallet?.balanceHidden">

--- a/src/components/wallet-item-content/wallet-item-content.ts
+++ b/src/components/wallet-item-content/wallet-item-content.ts
@@ -21,6 +21,13 @@ export class WalletItemContent {
         wallet.cachedStatus &&
         wallet.cachedStatus.totalBalanceStr &&
         wallet.cachedStatus.totalBalanceStr.replace(` ${currency}`, '');
+
+      // New created wallet does not have "lastkKnownBalance"
+      if (
+        totalBalanceStr == '0.00' &&
+        (lastKnownBalance == '0.00' || !lastKnownBalance)
+      )
+        return '0';
       return totalBalanceStr || lastKnownBalance;
     }
   }
@@ -33,6 +40,7 @@ export class WalletItemContent {
     } else {
       const totalBalanceAlternative =
         wallet.cachedStatus && wallet.cachedStatus.totalBalanceAlternative;
+      if (totalBalanceAlternative == '0.00') return '0';
       return totalBalanceAlternative;
     }
   }
@@ -41,14 +49,6 @@ export class WalletItemContent {
     return (
       wallet.lastKnownBalance &&
       wallet.lastKnownBalance.replace(` ${currency}`, '')
-    );
-  }
-
-  hasZeroBalance(wallet, currency) {
-    return (
-      (wallet.cachedStatus &&
-        wallet.cachedStatus.totalBalanceAlternative === 0) ||
-      this.getLastKownBalance(wallet, currency) === '0.00'
     );
   }
 }


### PR DESCRIPTION
Issues

* If wallet has been created recently, balance 0. After received funds, I had to restart the app to see new balance in the list of wallets.
* `hasZeroBalance` lock the value in zero, due to cached info is empty (for recently created wallet).