### PR TITLE
Fixes and improvements for buy crypto

### DIFF
--- a/src/pages/buy-crypto/crypto-offers/crypto-offers.html
+++ b/src/pages/buy-crypto/crypto-offers/crypto-offers.html
@@ -36,7 +36,12 @@
         </div>
         <div class="content" translate *ngIf="offer.value.fiatMoney || offer.value.errorMsg">
           <div *ngIf="offer.value.errorMsg">
-            <div class="main-label">{{offer.value.errorMsg}}</div>
+            <div class="main-label error-label">
+              <span class="error-title">Error: </span>
+              <span class="error-msg">
+                {{offer.value.errorMsg}}
+              </span>
+            </div>
           </div>
 
           <div class="visible-container">
@@ -108,8 +113,8 @@
                     1.5% of the amount.
                   </span>
                   <span *ngIf="paymentMethod.method != 'sepaBankTransfer'">
-                    <span translate>Can range from 6% of the transaction and down depending on the volume of traffic (with a minimum of 10 USD).</span>
-                    <a (click)="openExternalLink('https://www.simplex.com/kb/what-service-fees-am-i-paying/')" translate>
+                    <span translate>Can range from 2.5% to 5% of the transaction, depending on the volume of traffic (with a minimum of 10 USD or its equivalent in any other fiat currency) + 1% of the transaction.</span>
+                    <a (click)="openExternalLink('https://support.simplex.com/hc/en-gb/articles/360014078420-What-fees-am-I-paying-')" translate>
                       Read more
                     </a>
                   </span>
@@ -125,8 +130,13 @@
                 <div>
                   <span translate>What service fees am I paying?</span>
                   <br>
-                  <span translate *ngIf="selectedCountry.shortCode == 'US'">2.9% of the amount + 0.30 USD per transactions</span>
-                  <span translate *ngIf="selectedCountry.shortCode != 'US'">3.9% of the amount + 0.30 USD per transactions</span>
+                  <span translate *ngIf="selectedCountry.shortCode == 'US'">5 USD minimum fee or 2.9% of the amount + 0.30 USD, whichever is greater + Required miners fee.</span>
+                  <span translate *ngIf="selectedCountry.shortCode != 'US'">5 USD minimum fee or 3.9% of the amount + 0.30 USD, whichever is greater + Required miners fee.</span>
+                  <span translate *ngIf="fiatCurrency?.toUpperCase() != 'USD'">Or its equivalent in {{ fiatCurrency?.toUpperCase() }}.</span>
+                  &nbsp;
+                  <a (click)="openExternalLink('https://support.sendwyre.com/en/articles/3359160-wyre-card-processing-fees')" translate>
+                    Read more
+                  </a>
                 </div>
                 <div>
                   <span translate>This service is provided by a third party, and you are subject to their </span>

--- a/src/pages/buy-crypto/crypto-offers/crypto-offers.scss
+++ b/src/pages/buy-crypto/crypto-offers/crypto-offers.scss
@@ -92,6 +92,16 @@ page-crypto-offers {
       font-size: 18px;
       line-height: 20px;
       color: black;
+      &.error-label {
+        .error-title {
+          color: color($colors, danger);
+          font-weight: bold;
+        }
+        .error-msg {
+          color: color($colors, danger);
+          font-size: 14px;
+        }
+      }
     }
 
     .secondary-label {

--- a/src/pages/buy-crypto/crypto-order-summary/crypto-order-summary.ts
+++ b/src/pages/buy-crypto/crypto-order-summary/crypto-order-summary.ts
@@ -219,9 +219,25 @@ export class CryptoOrderSummaryPage {
   }
 
   private setDefaultPaymentMethod() {
-    this.paymentMethod = this.platformProvider.isIOS
-      ? this.buyCryptoProvider.paymentMethodsAvailable.applePay
-      : this.buyCryptoProvider.paymentMethodsAvailable.debitCard;
+    if (this.platformProvider.isIOS) {
+      this.paymentMethod =
+        this.buyCryptoProvider.isPaymentMethodSupported(
+          'simplex',
+          this.buyCryptoProvider.paymentMethodsAvailable.applePay,
+          this.coin,
+          this.currency
+        ) ||
+        this.buyCryptoProvider.isPaymentMethodSupported(
+          'wyre',
+          this.buyCryptoProvider.paymentMethodsAvailable.applePay,
+          this.coin,
+          this.currency
+        )
+          ? this.buyCryptoProvider.paymentMethodsAvailable.applePay
+          : this.buyCryptoProvider.paymentMethodsAvailable.debitCard;
+    } else {
+      this.paymentMethod = this.buyCryptoProvider.paymentMethodsAvailable.debitCard;
+    }
   }
 
   private checkPaymentMethod() {

--- a/src/pages/buy-crypto/crypto-payment-method/crypto-payment-method.html
+++ b/src/pages/buy-crypto/crypto-payment-method/crypto-payment-method.html
@@ -5,7 +5,7 @@
     </button>
   </ion-buttons>
   <div page-content>
-    <ion-list class="bp-list" radio-group [(ngModel)]="methodSelected" (ionChange)="save()">
+    <ion-list class="bp-list" radio-group [(ngModel)]="methodSelected">
       <div *ngFor="let method of methods | keys">
         <ion-item>
           <ion-label>
@@ -16,7 +16,7 @@
               <img *ngIf="showExchange('wyre', method.value)" [src]="themeProvider.currentAppTheme !== 'dark' ? 'assets/img/wyre/logo-wyre.svg' : 'assets/img/wyre/logo-wyre-dm.svg'">
             </div>
           </ion-label>
-          <ion-radio item-left value="{{method?.key}}" checked="methodSelected"></ion-radio>
+          <ion-radio (click)="save()" item-left value="{{method?.key}}" checked="methodSelected"></ion-radio>
           <ion-icon item-end class="item-img">
             <img src="{{method.value.imgSrc}}">
           </ion-icon>

--- a/src/pages/buy-crypto/crypto-payment-method/crypto-payment-method.ts
+++ b/src/pages/buy-crypto/crypto-payment-method/crypto-payment-method.ts
@@ -100,12 +100,7 @@ export class CryptoPaymentMethodPage {
   }
 
   public save() {
-    if (
-      !this.useAsModal ||
-      !this.methodSelected ||
-      this.navParams.data.paymentMethod == this.methodSelected
-    )
-      return;
+    if (!this.useAsModal || !this.methodSelected) return;
     this.viewCtrl.dismiss({ paymentMethod: this.methods[this.methodSelected] });
   }
 }

--- a/src/pages/exchange-crypto/exchange-checkout/exchange-checkout.ts
+++ b/src/pages/exchange-crypto/exchange-checkout/exchange-checkout.ts
@@ -11,6 +11,7 @@ import { ChangellyTermsPage } from '../../integrations/changelly/changelly-terms
 
 // Providers
 import { ActionSheetProvider } from '../../../providers/action-sheet/action-sheet';
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
 import { BwcErrorProvider } from '../../../providers/bwc-error/bwc-error';
 import { BwcProvider } from '../../../providers/bwc/bwc';
 import { ChangellyProvider } from '../../../providers/changelly/changelly';
@@ -66,6 +67,7 @@ export class ExchangeCheckoutPage {
 
   constructor(
     private actionSheetProvider: ActionSheetProvider,
+    private analyticsProvider: AnalyticsProvider,
     private logger: Logger,
     private navParams: NavParams,
     private modalCtrl: ModalController,
@@ -517,6 +519,11 @@ export class ExchangeCheckoutPage {
       this.logger.debug(
         'Saved exchange with status: ' + (newData.status || newData.error)
       );
+      this.analyticsProvider.logEvent('exchange_crypto_payment_sent', {
+        userId: this.fromWalletSelected.id,
+        coinFrom: this.fromWalletSelected.coin,
+        coinTo: this.toWalletSelected.coin
+      });
       this.openFinishModal();
     });
   }

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -758,7 +758,9 @@ export class HomePage {
   }
 
   public goToAmountPage() {
-    this.analyticsProvider.logEvent('buy_crypto_button_clicked', {});
+    this.analyticsProvider.logEvent('buy_crypto_button_clicked', {
+      from: 'homePage'
+    });
     this.navCtrl.push(AmountPage, {
       fromBuyCrypto: true,
       nextPage: 'CryptoOrderSummaryPage',
@@ -767,7 +769,9 @@ export class HomePage {
   }
 
   public goToExchangeCryptoPage() {
-    this.analyticsProvider.logEvent('exchange_crypto_button_clicked', {});
+    this.analyticsProvider.logEvent('exchange_crypto_button_clicked', {
+      from: 'homePage'
+    });
     this.navCtrl.push(ExchangeCryptoPage, {
       currency: this.configProvider.get().wallet.settings.alternativeIsoCode
     });

--- a/src/pages/home/price-page/price-page.html
+++ b/src/pages/home/price-page/price-page.html
@@ -31,7 +31,7 @@
         </ion-chip>
       </div>
     </span>
-    <button ion-button class="button-standard" (click)="goToAmountPage()">
+    <button ion-button class="button-standard" *ngIf="card.unitCode != 'xrp'" (click)="goToAmountPage()">
       Buy {{ card.name }}
     </button>
   </ion-toolbar>

--- a/src/pages/home/price-page/price-page.ts
+++ b/src/pages/home/price-page/price-page.ts
@@ -192,7 +192,9 @@ export class PricePage {
   }
 
   public goToAmountPage(): void {
-    this.analyticsProvider.logEvent('buy_crypto_button_clicked', {});
+    this.analyticsProvider.logEvent('buy_crypto_button_clicked', {
+      from: 'priceChartsPage'
+    });
     this.navCtrl.push(AmountPage, {
       coin: this.card.unitCode,
       fromBuyCrypto: true,

--- a/src/pages/home/price-page/price-page.ts
+++ b/src/pages/home/price-page/price-page.ts
@@ -193,7 +193,8 @@ export class PricePage {
 
   public goToAmountPage(): void {
     this.analyticsProvider.logEvent('buy_crypto_button_clicked', {
-      from: 'priceChartsPage'
+      from: 'priceChartsPage',
+      coin: this.card.unitCode
     });
     this.navCtrl.push(AmountPage, {
       coin: this.card.unitCode,

--- a/src/pages/integrations/simplex/simplex.ts
+++ b/src/pages/integrations/simplex/simplex.ts
@@ -6,6 +6,7 @@ import * as _ from 'lodash';
 import { SimplexDetailsPage } from './simplex-details/simplex-details';
 
 // Proviers
+import { AnalyticsProvider } from '../../../providers/analytics/analytics';
 import { ExternalLinkProvider } from '../../../providers/external-link/external-link';
 import { Logger } from '../../../providers/logger/logger';
 import { SimplexProvider } from '../../../providers/simplex/simplex';
@@ -22,6 +23,7 @@ export class SimplexPage {
   public service;
 
   constructor(
+    private analyticsProvider: AnalyticsProvider,
     private logger: Logger,
     private externalLinkProvider: ExternalLinkProvider,
     private modalCtrl: ModalController,
@@ -53,6 +55,14 @@ export class SimplexPage {
             this.navParams.data.success === 'true' ? 'success' : 'failed';
           this.simplexProvider
             .saveSimplex(simplexData[this.navParams.data.paymentId], null)
+            .then(() => {
+              if (this.navParams.data.userId) {
+                this.analyticsProvider.logEvent('buy_crypto_payment_success', {
+                  exchange: 'simplex',
+                  userId: this.navParams.data.userId
+                });
+              }
+            })
             .catch(() => {
               this.logger.warn('Could not update payment request status');
             });

--- a/src/pages/integrations/wyre/wyre-details/wyre-details.html
+++ b/src/pages/integrations/wyre/wyre-details/wyre-details.html
@@ -82,6 +82,17 @@
       </div>
     </ion-item>
 
+    <ion-item *ngIf="paymentRequest.paymentMethodName">
+      {{'Payment method' | translate}}
+      <div padding-top>
+        <ion-note text-wrap>
+          <span copy-to-clipboard="{{paymentRequest.paymentMethodName}}">
+            {{ paymentRequest.paymentMethodName }}
+          </span>
+        </ion-note>
+      </div>
+    </ion-item>
+
     <ion-item>
       Transfer ID
       <div padding-top>

--- a/src/pages/integrations/wyre/wyre-details/wyre-details.ts
+++ b/src/pages/integrations/wyre/wyre-details/wyre-details.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { NavParams, ViewController } from 'ionic-angular';
+import * as _ from 'lodash';
 
 // Providers
 import { ExternalLinkProvider } from '../../../../providers/external-link/external-link';
@@ -27,8 +28,9 @@ export class WyreDetailsPage {
     public themeProvider: ThemeProvider
   ) {
     this.paymentRequest = this.navParams.data.paymentRequestData;
-    this.paymentRequest.fiatBaseAmount =
-      +this.paymentRequest.sourceAmount - +this.paymentRequest.fee;
+    this.paymentRequest.fiatBaseAmount = this.paymentRequest.purchaseAmount
+      ? this.paymentRequest.purchaseAmount
+      : +this.paymentRequest.sourceAmount - +this.paymentRequest.fee;
   }
 
   ionViewDidLoad() {
@@ -37,37 +39,89 @@ export class WyreDetailsPage {
 
   ionViewWillEnter() {
     if (
-      this.paymentRequest.status != 'success' &&
-      this.paymentRequest.transferId
+      this.paymentRequest.orderId &&
+      (this.paymentRequest.status != 'success' ||
+        !this.paymentRequest.transferId ||
+        (this.paymentRequest.transferId &&
+          !this.paymentRequest.blockchainNetworkTx))
     ) {
-      this.logger.info('Wyre Details: trying to get transaction info');
+      this.logger.info('Wyre Details: trying to get order details data');
       this.wyreProvider
-        .getTransfer(this.navParams.data.transferId)
-        .then((transferData: any) => {
-          this.paymentRequest.status = 'success';
-          this.paymentRequest.sourceAmount = transferData.sourceAmount;
-          this.paymentRequest.fee = transferData.fee; // Total fee (crypto fee + Wyre fee)
-          this.paymentRequest.destCurrency = transferData.destCurrency;
-          this.paymentRequest.sourceCurrency = transferData.sourceCurrency;
+        .getWalletOrderDetails(this.paymentRequest.orderId)
+        .then((orderData: any) => {
+          this.logger.debug('Wyre get order details: SUCCESS!');
+          this.logger.debug('order Data: ', orderData);
+          if (orderData && !_.isEmpty(orderData)) {
+            switch (orderData.status) {
+              case 'RUNNING_CHECKS':
+                this.paymentRequest.status = 'paymentRequestSent';
+                break;
+              case 'PROCESSING':
+                this.paymentRequest.status = 'paymentRequestSent';
+                break;
+              case 'FAILED':
+                this.paymentRequest.status = 'failed';
+                break;
+              case 'COMPLETE':
+                this.paymentRequest.status = 'success';
+                break;
+              default:
+                this.paymentRequest.status = 'paymentRequestSent';
+                break;
+            }
+            this.paymentRequest.sourceAmount = orderData.sourceAmount;
+            this.paymentRequest.fee =
+              orderData.sourceAmount &&
+              orderData.purchaseAmount &&
+              orderData.sourceAmount - orderData.purchaseAmount >= 0
+                ? orderData.sourceAmount - orderData.purchaseAmount
+                : null; // Total fee (crypto fee + Wyre fee)
+            this.paymentRequest.destCurrency = orderData.destCurrency;
+            this.paymentRequest.sourceCurrency = orderData.sourceCurrency;
 
-          this.wyreProvider
-            .saveWyre(this.paymentRequest, null)
-            .then(() => {
-              this.logger.debug(
-                'Saved Wyre with transferId: ' + this.navParams.data.transferId
-              );
-            })
-            .catch(() => {
-              this.logger.warn('Could not update payment request status');
-            });
+            if (orderData.transferId) {
+              this.paymentRequest.transferId = orderData.transferId;
+              this.logger.info('Wyre Details: trying to get transaction info');
+              this.wyreProvider
+                .getTransfer(this.paymentRequest.transferId)
+                .then((transferData: any) => {
+                  this.paymentRequest.blockchainNetworkTx =
+                    transferData.blockchainNetworkTx;
+                  this.paymentRequest.destAmount = transferData.destAmount;
+                  this.saveWyrePaymentRequest();
+                })
+                .catch(_err => {
+                  this.logger.warn(
+                    'Could not get transfer for transferId: ' +
+                      this.paymentRequest.transferId
+                  );
+                  this.saveWyrePaymentRequest();
+                });
+            } else {
+              this.saveWyrePaymentRequest();
+            }
+          }
         })
         .catch(_err => {
           this.logger.warn(
-            'Could not get transfer for transferId: ' +
-              this.navParams.data.transferId
+            'Could not get order details for orderId: ' +
+              this.paymentRequest.orderId
           );
         });
     }
+  }
+
+  private saveWyrePaymentRequest() {
+    this.wyreProvider
+      .saveWyre(this.paymentRequest, null)
+      .then(() => {
+        this.logger.debug(
+          'Saved Wyre with orderId: ' + this.paymentRequest.orderId
+        );
+      })
+      .catch(() => {
+        this.logger.warn('Could not update payment request status');
+      });
   }
 
   public remove() {
@@ -86,7 +140,7 @@ export class WyreDetailsPage {
               remove: true
             })
             .then(() => {
-              this.close();
+              this.close(this.paymentRequest.orderId);
             });
         }
       });
@@ -96,7 +150,7 @@ export class WyreDetailsPage {
     this.externalLinkProvider.open(url);
   }
 
-  public close() {
-    this.viewCtrl.dismiss();
+  public close(removedPaymentRequest?: string) {
+    this.viewCtrl.dismiss({ removedPaymentRequest });
   }
 }

--- a/src/pages/onboarding/add-funds/add-funds.ts
+++ b/src/pages/onboarding/add-funds/add-funds.ts
@@ -62,7 +62,9 @@ export class AddFundsPage {
       return;
     }
 
-    this.analyticsProvider.logEvent('buy_crypto_button_clicked', {});
+    this.analyticsProvider.logEvent('buy_crypto_button_clicked', {
+      from: 'addFundsPage'
+    });
     this.navCtrl.push(AmountPage, {
       fromBuyCrypto: true,
       nextPage: 'CryptoOrderSummaryPage',

--- a/src/pages/send/amount/amount.html
+++ b/src/pages/send/amount/amount.html
@@ -58,8 +58,7 @@
       <pin-pad (keystroke)="pushDigit($event)" type="amount" [integersOnly]="onlyIntegers"></pin-pad>
 
       <button ion-button class="button-standard button-primary" [disabled]="!expression || !allowSend" (click)="finish()">
-        <span *ngIf="!fromBuyCrypto">{{'Continue' | translate}}</span>
-        <span *ngIf="fromBuyCrypto">{{'Select Payment Method' | translate}}</span>
+        <span>{{'Continue' | translate}}</span>
       </button>
     </div>
   </div>

--- a/src/pages/wallet-details/wallet-details.ts
+++ b/src/pages/wallet-details/wallet-details.ts
@@ -694,7 +694,8 @@ export class WalletDetailsPage {
       });
     } else {
       this.analyticsProvider.logEvent('exchange_crypto_button_clicked', {
-        from: 'walletDetails'
+        from: 'walletDetails',
+        coin: this.wallet.coin
       });
       this.navCtrl.push(ExchangeCryptoPage, {
         walletId: this.wallet.id
@@ -711,7 +712,8 @@ export class WalletDetailsPage {
       });
     } else {
       this.analyticsProvider.logEvent('buy_crypto_button_clicked', {
-        from: 'walletDetails'
+        from: 'walletDetails',
+        coin: this.wallet.coin
       });
       this.navCtrl.push(AmountPage, {
         coin: this.wallet.coin,

--- a/src/pages/wallet-details/wallet-details.ts
+++ b/src/pages/wallet-details/wallet-details.ts
@@ -693,7 +693,9 @@ export class WalletDetailsPage {
         if (data === 'goToBackup') this.goToBackup();
       });
     } else {
-      this.analyticsProvider.logEvent('exchange_crypto_button_clicked', {});
+      this.analyticsProvider.logEvent('exchange_crypto_button_clicked', {
+        from: 'walletDetails'
+      });
       this.navCtrl.push(ExchangeCryptoPage, {
         walletId: this.wallet.id
       });
@@ -708,7 +710,9 @@ export class WalletDetailsPage {
         if (data === 'goToBackup') this.goToBackup();
       });
     } else {
-      this.analyticsProvider.logEvent('buy_crypto_button_clicked', {});
+      this.analyticsProvider.logEvent('buy_crypto_button_clicked', {
+        from: 'walletDetails'
+      });
       this.navCtrl.push(AmountPage, {
         coin: this.wallet.coin,
         fromBuyCrypto: true,

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -721,25 +721,43 @@ export class IncomingDataProvider {
     if (data === this.appProvider.info.name + '://wyre') return;
     const res = data.replace(new RegExp('&amp;', 'g'), '&');
     const transferId = this.getParameterByName('transferId', res);
-    const referenceId = this.getParameterByName('referenceId', res);
-    const orderId = this.getParameterByName('orderId', res);
+    const walletId = this.getParameterByName('walletId', res);
+    const owner = this.getParameterByName('owner', res);
+    const orderId = this.getParameterByName('id', res);
     const accountId = this.getParameterByName('accountId', res);
     const dest = this.getParameterByName('dest', res);
-    const fees = this.getParameterByName('fees', res);
     const destAmount = this.getParameterByName('destAmount', res);
+    const destCurrency = this.getParameterByName('destCurrency', res);
+    const purchaseAmount = this.getParameterByName('purchaseAmount', res);
+    const sourceAmount = this.getParameterByName('sourceAmount', res);
+    const sourceCurrency = this.getParameterByName('sourceCurrency', res);
+    const status = this.getParameterByName('status', res);
+    const createdAt = this.getParameterByName('createdAt', res);
+    const paymentMethodName = this.getParameterByName('paymentMethodName', res);
     const blockchainNetworkTx = this.getParameterByName(
       'blockchainNetworkTx',
       res
     );
+    if (!orderId) {
+      this.logger.debug('No orderId present. Do not redir');
+      return;
+    }
 
     const stateParams = {
       transferId,
-      referenceId,
+      walletId,
+      owner,
       orderId,
       accountId,
       dest,
-      fees,
       destAmount,
+      destCurrency,
+      purchaseAmount,
+      sourceAmount,
+      sourceCurrency,
+      status,
+      createdAt,
+      paymentMethodName,
       blockchainNetworkTx
     };
     const nextView = {

--- a/src/providers/incoming-data/incoming-data.ts
+++ b/src/providers/incoming-data/incoming-data.ts
@@ -721,6 +721,7 @@ export class IncomingDataProvider {
     if (data === this.appProvider.info.name + '://wyre') return;
     const res = data.replace(new RegExp('&amp;', 'g'), '&');
     const transferId = this.getParameterByName('transferId', res);
+    const referenceId = this.getParameterByName('referenceId', res);
     const orderId = this.getParameterByName('orderId', res);
     const accountId = this.getParameterByName('accountId', res);
     const dest = this.getParameterByName('dest', res);
@@ -733,6 +734,7 @@ export class IncomingDataProvider {
 
     const stateParams = {
       transferId,
+      referenceId,
       orderId,
       accountId,
       dest,

--- a/src/providers/wyre/wyre.ts
+++ b/src/providers/wyre/wyre.ts
@@ -209,12 +209,13 @@ export class WyreProvider {
         data = JSON.parse(data);
       }
       let inv = oldData ? oldData : {};
-      inv[data.transferId] = data;
+      inv[data.orderId] = data;
       if (opts && (opts.error || opts.status)) {
-        inv[data.transferId] = _.assign(inv[data.transferId], opts);
+        inv[data.orderId] = _.assign(inv[data.orderId], opts);
       }
       if (opts && opts.remove) {
-        delete inv[data.transferId];
+        if (inv[data.transferId]) delete inv[data.transferId];
+        if (inv[data.orderId]) delete inv[data.orderId];
       }
 
       inv = JSON.stringify(inv);

--- a/src/providers/wyre/wyre.ts
+++ b/src/providers/wyre/wyre.ts
@@ -41,7 +41,7 @@ export class WyreProvider {
       'wbtc'
     ];
     this.fiatAmountLimits = {
-      min: 1,
+      min: 20,
       max: 1000
     };
   }
@@ -96,10 +96,10 @@ export class WyreProvider {
   ) {
     let min, max: number;
     if (!country || country != 'US') {
-      min = 1;
+      min = 20;
       max = 1000;
     } else {
-      min = 1;
+      min = 20;
       max = 500;
     }
     this.fiatAmountLimits.min = this.calculateFiatRate(min, fiatCurrency, coin);
@@ -159,6 +159,24 @@ export class WyreProvider {
       env: this.env
     };
     return wallet.wyreUrlParams(data);
+  }
+
+  public getWalletOrderDetails(orderId: string) {
+    const url = this.uri + '/v3/orders/' + orderId;
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    return new Promise((resolve, reject) => {
+      this.http.get(url, { headers }).subscribe(
+        data => {
+          return resolve(data);
+        },
+        err => {
+          return reject(err);
+        }
+      );
+    });
   }
 
   public getTransfer(transferId: string) {


### PR DESCRIPTION
This PR needs: https://github.com/bitpay/bitcore/pull/3064/files
Anyway, it can be tested by sending the amount parameter with null

Fixes:
- Remove "Buy XRP" from charts page
- Wyre's redirectUrl has been fixed to return to the app after a purchase
- Crypto purchases not supported by Wyre will no longer set Apple pay by default. It will set debit card
- Now you can select the same payment method that was previously selected
- Error messages in buy crypto are now red
- The amount page button now says "Continue" (instead of "Select payment method")

Improvements:
- New analytics events to Buy / Exchange crypto with more data
- Refactored Wyre integration to work with the latest changes to its documentation.
- Consistency between the offer shown by Wyre and Simplex => Refactor in Wyre's getOffer function
- Improved the explanation about buy crypto fees
