### PR TITLE
[FIX] iab pause lock disabled

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -221,17 +221,6 @@ export class CopayApp {
         deviceInfo
     );
 
-    this.platform.pause.subscribe(() => {
-      const config = this.configProvider.get();
-      const lockMethod =
-        config && config.lock && config.lock.method
-          ? config.lock.method.toLowerCase()
-          : null;
-      if (!lockMethod || lockMethod === 'disabled') {
-        return;
-      }
-    });
-
     this.logger.debug('BitPay: setting network');
     [
       this.bitpayProvider,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -451,7 +451,7 @@ export class CopayApp {
         ? config.lock.method.toLowerCase()
         : null;
 
-    if (!lockMethod) {
+    if (!lockMethod || lockMethod === 'disabled') {
       return;
     }
 


### PR DESCRIPTION
- removed unused
- prevents the in app browser from pausing when lockMethod is disabled