### PR TITLE
Fix perpetual spinner when buying a gift card in some cases

### DIFF
--- a/src/pages/integrations/gift-cards/purchased-cards/purchased-cards.ts
+++ b/src/pages/integrations/gift-cards/purchased-cards/purchased-cards.ts
@@ -35,6 +35,7 @@ export class PurchasedCardsPage {
     this.cardConfig = await this.giftCardProvider.getCardConfig(cardName);
     await this.getCards();
     this.listenForUpdates();
+    this.giftCardProvider.refreshActiveGiftCards();
   }
 
   async ionViewDidLoad() {

--- a/src/providers/gift-card/gift-card.ts
+++ b/src/providers/gift-card/gift-card.ts
@@ -222,7 +222,7 @@ export class GiftCardProvider extends InvoiceProvider {
     const validSchema =
       giftCardMap && Object.keys(giftCardMap).every(key => key !== 'undefined');
     return !giftCardMap || !validSchema
-      ? this.migrateAndFetchActiveCards()
+      ? this.refreshActiveGiftCards()
       : getCardsFromInvoiceMap(giftCardMap, configMap);
   }
 
@@ -558,7 +558,7 @@ export class GiftCardProvider extends InvoiceProvider {
     );
   }
 
-  async migrateAndFetchActiveCards(): Promise<GiftCard[]> {
+  async refreshActiveGiftCards(): Promise<GiftCard[]> {
     await this.clearActiveGiftCards();
     const purchasedBrands = await this.getPurchasedBrands();
     const activeCardsGroupedByBrand = purchasedBrands.filter(


### PR DESCRIPTION
A few users have reported a bug that results in a perpetual spinner being shown when they attempt to purchase a specific gift card brand in the BitPay app which makes it impossible for them to purchase any gift cards for that particular brand. This PR fixes that issue.