### PR TITLE
APP-72 [Feat] Call clearCache endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "apple-wallet-ng": "1.1.1",
     "base64-js": "1.3.0",
     "bitauth": "git+https://github.com/bitpay/bitauth.git#6bfe7df3d1cde303507d29a9d9c98b1f429ba46e",
-    "bitcore-wallet-client": "8.24.2",
+    "bitcore-wallet-client": "8.25.1",
     "buffer-compare": "1.1.1",
     "chart.js": "2.8.0",
     "cordova": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "apple-wallet-ng": "1.1.1",
     "base64-js": "1.3.0",
     "bitauth": "git+https://github.com/bitpay/bitauth.git#6bfe7df3d1cde303507d29a9d9c98b1f429ba46e",
-    "bitcore-wallet-client": "8.25.1",
+    "bitcore-wallet-client": "8.25.2",
     "buffer-compare": "1.1.1",
     "chart.js": "2.8.0",
     "cordova": "9.0.0",

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -731,7 +731,7 @@ export class WalletProvider {
     });
   }
 
-  public clearCache(wallet): Promise<any> {
+  clearWalletCache(wallet): Promise<boolean> {
     return new Promise(resolve => {
       const config = this.configProvider.get();
       const defaults = this.configProvider.getDefaults();
@@ -1471,7 +1471,7 @@ export class WalletProvider {
   public clearTxHistory(wallet): void {
     this.invalidateCache(wallet);
     this.persistenceProvider.removeTxHistory(wallet.id);
-    this.clearCache(wallet)
+    this.clearWalletCache(wallet)
       .then(() => {
         this.logger.info(
           `TxHistory cache cleared from server for: ${wallet.id}`

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -735,14 +735,14 @@ export class WalletProvider {
     return new Promise(resolve => {
       const config = this.configProvider.get();
       const defaults = this.configProvider.getDefaults();
-      const bws_url = (config.bwsFor && config.bwsFor[wallet.id]) || defaults.bws.url;
+      const bws_url =
+        (config.bwsFor && config.bwsFor[wallet.id]) || defaults.bws.url;
       this.bwcProvider
         .getClient(JSON.stringify(wallet.credentials), {
           bwsurl: bws_url
         })
-        .clearCache((err, res) => {
+        .clearCache(err => {
           if (err) resolve(false);
-          console.log(`${JSON.stringify(res)}`);
           return resolve(true);
         });
     });
@@ -1472,8 +1472,10 @@ export class WalletProvider {
     this.invalidateCache(wallet);
     this.persistenceProvider.removeTxHistory(wallet.id);
     this.clearCache(wallet)
-      .then( () => {
-        this.logger.info(`TxHistory cache cleared from server for: ${wallet.id}`);
+      .then(() => {
+        this.logger.info(
+          `TxHistory cache cleared from server for: ${wallet.id}`
+        );
       })
       .catch(err => {
         this.logger.error(err);

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -731,6 +731,23 @@ export class WalletProvider {
     });
   }
 
+  public clearCache(wallet): Promise<any> {
+    return new Promise(resolve => {
+      const config = this.configProvider.get();
+      const defaults = this.configProvider.getDefaults();
+      const bws_url = (config.bwsFor && config.bwsFor[wallet.id]) || defaults.bws.url;
+      this.bwcProvider
+        .getClient(JSON.stringify(wallet.credentials), {
+          bwsurl: bws_url
+        })
+        .clearCache((err, res) => {
+          if (err) resolve(false);
+          console.log(`${JSON.stringify(res)}`);
+          return resolve(true);
+        });
+    });
+  }
+
   private updateLocalTxHistory(
     wallet,
     progressFn,
@@ -1454,6 +1471,13 @@ export class WalletProvider {
   public clearTxHistory(wallet): void {
     this.invalidateCache(wallet);
     this.persistenceProvider.removeTxHistory(wallet.id);
+    this.clearCache(wallet)
+      .then( () => {
+        this.logger.info(`TxHistory cache cleared from server for: ${wallet.id}`);
+      })
+      .catch(err => {
+        this.logger.error(err);
+      });
   }
 
   public expireAddress(walletId: string): Promise<any> {


### PR DESCRIPTION
Add call to clearCache endpoint from WalletTransactionHistory to clear cache from server

Need to deploy: [bitpay/bitcore#3066](https://github.com/bitpay/bitcore/pull/3066)

Have to wait to update of bitcore-wallet-client with the clearCache API function.