### PR TITLE
WIP fix(iab): close instances on pause and restart it on resume event

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -279,14 +279,16 @@ export class CopayApp {
       this.onPauseSubscription = this.platform.pause.subscribe(async () => {
         // Since Biometric plugin put on Pause Android devices,
         // it's needed to close all iab instances
-        if (this.platform.is('android')) this.closeIAB();
+        if (this.platform.is('android') && this.iabCardProvider.isHidden)
+          this.closeIAB();
       });
 
       // Subscribe Resume
       this.logger.debug('On Resume Subscription');
       this.onResumeSubscription = this.platform.resume.subscribe(async () => {
         // Resume InAppBrowser (only Android)
-        if (this.platform.is('android')) this.initIAB();
+        if (this.platform.is('android') && this.iabCardProvider.isHidden)
+          this.initIAB();
 
         // Check PIN or Fingerprint on Resume
         this.openLockModal();


### PR DESCRIPTION
Fixed errors:

- [x] having biometric on -> opening the in app browser -> closing it -> going to settings -> lock settings -> in app browser shows
- [x] having biometric on (for app and wallet) → try to send funds → it asks for biometric twice

Needs review:

* Top up card balance: if app is closed (paused) on the Confirm view, and then back to the main Card view, the app get freezes. It works if send is confirmed.
* Open iab and closing the app, it will resume on the "Card" tab.