### PR TITLE
Catch removeTx errors during gift card purchases

### DIFF
--- a/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
+++ b/src/pages/integrations/gift-cards/confirm-card-purchase/confirm-card-purchase.ts
@@ -333,7 +333,6 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
       const err = this.translate.instant('No signing proposal: No private key');
       return Promise.reject(err);
     }
-
     await this.walletProvider.publishAndSign(wallet, txp);
     return this.onGoingProcessProvider.clear();
   }
@@ -841,7 +840,7 @@ export class ConfirmCardPurchasePage extends ConfirmPage {
     await this.giftCardProvider.saveCard(this.tx.giftData, {
       remove: true
     });
-    await this.walletProvider.removeTx(this.wallet, this.tx);
+    await this.walletProvider.removeTx(this.wallet, this.tx).catch(() => {});
     const errorMessage = err && err.message;
     const canceledErrors = ['FINGERPRINT_CANCELLED', 'PASSWORD_CANCELLED'];
     if (canceledErrors.indexOf(errorMessage) !== -1) {

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -1681,46 +1681,15 @@ export class WalletProvider {
     });
   }
 
-  public publishAndSign(wallet, txp): Promise<any> {
-    return new Promise((resolve, reject) => {
-      // Already published?
-      if (txp.status == 'pending') {
-        this.prepare(wallet)
-          .then((password: string) => {
-            this.signAndBroadcast(wallet, txp, password)
-              .then(broadcastedTxp => {
-                return resolve(broadcastedTxp);
-              })
-              .catch(err => {
-                return reject(err);
-              });
-          })
-          .catch(err => {
-            return reject(err);
-          });
-      } else {
-        this.prepare(wallet)
-          .then((password: string) => {
-            this.onGoingProcessProvider.set('sendingTx');
-            this.publishTx(wallet, txp)
-              .then(publishedTxp => {
-                this.signAndBroadcast(wallet, publishedTxp, password)
-                  .then(broadcastedTxp => {
-                    return resolve(broadcastedTxp);
-                  })
-                  .catch(err => {
-                    return reject(err);
-                  });
-              })
-              .catch(err => {
-                return reject(err);
-              });
-          })
-          .catch(err => {
-            return reject(err);
-          });
-      }
-    });
+  public async publishAndSign(wallet, txp): Promise<any> {
+    const password = await this.prepare(wallet);
+    // Already published?
+    if (txp.status == 'pending') {
+      return this.signAndBroadcast(wallet, txp, password);
+    }
+    this.onGoingProcessProvider.set('sendingTx');
+    const publishedTxp = await this.publishTx(wallet, txp);
+    return this.signAndBroadcast(wallet, publishedTxp, password);
   }
 
   public signMultipleTxps(wallet, txps: any[]): Promise<any> {


### PR DESCRIPTION
Fix for the perpetual spinner issue that occurs when some users try to buy a gift card but enter their encrypt password incorrectly.

Also simplifies the `publishAndSign` method in wallet provider.

