### PR TITLE
[FIX] hiding switcher if cardTop

### DIFF
--- a/src/pages/send/amount/amount.html
+++ b/src/pages/send/amount/amount.html
@@ -36,7 +36,7 @@
       </div>
     </div>
 
-    <div class="amount-switcher-margin" [ngClass]="{'fix-modal-switcher': useAsModal}" *ngIf="!fromBuyCrypto">
+    <div class="amount-switcher-margin" [ngClass]="{'fix-modal-switcher': useAsModal}" *ngIf="!fromBuyCrypto && !isCardTopUp">
       <div class="amount-switcher">
         <div class="switcher" (click)="changeUnit()" [hidden]="fixedUnit" tappable>
           <img class="switcher__icon" src="assets/img/icon-swap.svg">

--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -95,6 +95,7 @@ export class AmountPage {
   private alternativeCurrency;
   public fromBuyCrypto: boolean;
   public fromExchangeCrypto: boolean;
+  public isCardTopUp: boolean;
   public quoteForm: FormGroup;
   public supportedFiatAltCurrencies: string[];
   public altCurrenciesToShow: string[];
@@ -149,7 +150,7 @@ export class AmountPage {
     this.alternativeCurrency = this.navParams.data.alternativeCurrency;
     this.fromBuyCrypto = this.navParams.data.fromBuyCrypto;
     this.fromExchangeCrypto = this.navParams.data.fromExchangeCrypto;
-
+    this.isCardTopUp = !!this.navParams.data.card;
     this.showSendMax = false;
     this.useSendMax = false;
     this.allowSend = false;


### PR DESCRIPTION
Hiding the switcher during card tops to prevent non-USD currency rate issues. 