### PR TITLE
[FIX] save logo uri instead of using the contract address

### DIFF
--- a/src/assets/img/default-erc20.svg
+++ b/src/assets/img/default-erc20.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="sc-1fvnadz-1 cnWwkh" style="margin-right: 0.5rem; color: rgb(86, 90, 105);"><circle cx="12" cy="12" r="10"></circle><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"></line></svg>

--- a/src/components/coin-icon/coin-icon.html
+++ b/src/components/coin-icon/coin-icon.html
@@ -3,5 +3,5 @@
 </ion-icon>
 
 <ion-icon *ngIf="coin && !currencyProvider.COIN[coin | uppercase]" color="success" class="item-img rectangle background_default" item-start>
-  <img src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(coin)}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'" />
+  <img src="{{currencyProvider.getLogoURI(coin)}}" />
 </ion-icon>

--- a/src/components/wallet-receive/wallet-receive.html
+++ b/src/components/wallet-receive/wallet-receive.html
@@ -53,7 +53,7 @@
       </div>
       <bp-qr-code *ngIf="address && !newAddressError  && !useLegacyQrCode" class="card qr-card" copy-to-clipboard="{{ address }}" contents="{{ address }}" mask-x-to-y-ratio="1">
         <img *ngIf="wallet.coin && currencyProvider.COIN[wallet.coin | uppercase]" [ngClass]="{'testnet': wallet.network === 'testnet', 'background_xrp': wallet.coin === 'xrp'}" src="assets/img/currencies/{{ wallet.coin }}.svg" slot="icon" />
-        <img *ngIf="wallet.coin && !currencyProvider.COIN[wallet.coin | uppercase]" src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(wallet.coin)}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'" slot="icon"/>
+        <img *ngIf="wallet.coin && !currencyProvider.COIN[wallet.coin | uppercase]" [src]="currencyProvider.getLogoURI(wallet.coin)" slot="icon"/>
       </bp-qr-code>
       <div *ngIf="address && useLegacyQrCode" class="card qr-card" copy-to-clipboard="{{ address }}">
         <ngx-qrcode hide-toast="true" qrc-value="{{ address }}" qrc-class="aclass" qrc-errorCorrectionLevel="M"></ngx-qrcode>

--- a/src/pages/add/custom-token/custom-token.ts
+++ b/src/pages/add/custom-token/custom-token.ts
@@ -215,12 +215,13 @@ export class CustomTokenPage {
     modal.present();
     modal.onWillDismiss(data => {
       if (data && data.token) {
-        const { name, address, symbol, decimals } = data.token;
+        const { name, address, symbol, decimals, logoURI } = data.token;
 
         this.createAndBindTokenWallet({
           keyId: this.keyId,
           name,
           address,
+          logoURI,
           symbol: symbol.toLowerCase(),
           decimals
         });

--- a/src/pages/add/select-currency/select-currency.html
+++ b/src/pages/add/select-currency/select-currency.html
@@ -19,7 +19,7 @@
             <img src="assets/img/currencies/{{token.symbol.toLowerCase()}}.svg" />
           </ion-icon>
           <ion-icon *ngIf="!currencyProvider.COIN[token.symbol | uppercase]" item-start>
-            <img src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(token.symbol.toLowerCase())}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'"/>
+            <img [src]="currencyProvider.getLogoURI(token.symbol.toLowerCase())"/>
           </ion-icon>
           <div class="item-title">{{ token.name }} ({{ token.symbol }})</div>
         </button>

--- a/src/pages/buy-crypto/crypto-offers/crypto-offers.html
+++ b/src/pages/buy-crypto/crypto-offers/crypto-offers.html
@@ -11,7 +11,7 @@
             <div class="summary-title" translate>Crypto</div>
             <div class="summary-description" [ngClass]="{'testnet': wallet.network === 'testnet'}">
               <img class="coin-icon" *ngIf="currencyProvider.COIN[coin | uppercase]" src="assets/img/currencies/{{coin.toLowerCase()}}.svg" />
-              <img class="coin-icon" *ngIf="!currencyProvider.COIN[coin | uppercase]" src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(coin.toLowerCase())}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'"/>
+              <img class="coin-icon" *ngIf="!currencyProvider.COIN[coin | uppercase]" [src]="currencyProvider.getLogoURI(coin.toLowerCase())"/>
               {{coin | uppercase}}
             </div>
           </ion-col>

--- a/src/pages/buy-crypto/crypto-order-summary/crypto-order-summary.html
+++ b/src/pages/buy-crypto/crypto-order-summary/crypto-order-summary.html
@@ -29,7 +29,7 @@
                 <img src="assets/img/currencies/{{wallet.coin.toLowerCase()}}.svg" />
               </ion-icon>
               <ion-icon *ngIf="!currencyProvider.COIN[wallet.coin | uppercase]" class="item-img" item-start>
-                <img src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(wallet.coin.toLowerCase())}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'"/>
+                <img [src]="currencyProvider.getLogoURI(token.symbol.toLowerCase())"/>
               </ion-icon>
               <span class="note-container ellipsis">{{wallet?.name}}</span>
               <ion-icon [name]="isOpenSelector.destination ? 'ios-arrow-up-outline' : 'ios-arrow-down-outline'"></ion-icon>

--- a/src/pages/coin-and-wallet-selector/coin-and-wallet-selector.html
+++ b/src/pages/coin-and-wallet-selector/coin-and-wallet-selector.html
@@ -21,7 +21,7 @@
           <img src="assets/img/currencies/{{coin.unitCode.toLowerCase()}}.svg" />
         </ion-icon>
         <ion-icon *ngIf="!currencyProvider.COIN[coin.unitCode | uppercase]" class="item-img" item-start>
-          <img src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(coin.unitCode.toLowerCase())}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'"/>
+          <img [src]="currencyProvider.getLogoURI(coin.unitCode.toLowerCase())"/>
         </ion-icon>
         <ion-label>
           <div class="main-label">{{coin.name}}</div>
@@ -41,7 +41,7 @@
           <img src="assets/img/currencies/{{coin.unitCode.toLowerCase()}}.svg" />
         </ion-icon>
         <ion-icon *ngIf="!currencyProvider.COIN[coin.unitCode | uppercase]" class="item-img" item-start>
-          <img src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(coin.unitCode.toLowerCase())}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'"/>
+          <img [src]="currencyProvider.getLogoURI(coin.unitCode.toLowerCase())"/>
         </ion-icon>
         <ion-label>
           <div class="main-label">{{coin.name}}</div>

--- a/src/pages/coin-and-wallet-selector/coin-and-wallet-selector.ts
+++ b/src/pages/coin-and-wallet-selector/coin-and-wallet-selector.ts
@@ -267,6 +267,7 @@ export class CoinAndWalletSelectorPage {
       keyId: pairedWallet.keyId,
       name: token.name,
       address: token.address,
+      logoURI: token.logoURI,
       symbol: token.symbol.toLowerCase(),
       decimals: token.decimals
     };

--- a/src/pages/exchange-crypto/exchange-crypto.html
+++ b/src/pages/exchange-crypto/exchange-crypto.html
@@ -75,7 +75,7 @@
                 <img src="assets/img/currencies/{{toWalletSelected.coin.toLowerCase()}}.svg" />
               </ion-icon>
               <ion-icon *ngIf="(!toToken || !toToken.isCustomToken) && !currencyProvider.COIN[toWalletSelected.coin | uppercase]" class="item-img" item-start>
-                <img src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(toWalletSelected.coin.toLowerCase())}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'"/>
+                <img [src]="currencyProvider.getLogoURI(toWalletSelected.coin.toLowerCase())"/>
               </ion-icon>
               <ion-icon *ngIf="toToken && toToken.isCustomToken" class="item-img" item-start>
                 <img width="20" [src]="toToken.logoURI" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'">

--- a/src/pages/includes/multiple-outputs/multiple-outputs.html
+++ b/src/pages/includes/multiple-outputs/multiple-outputs.html
@@ -11,7 +11,7 @@
     <div class="payment-proposal-to" *ngIf="!tx.hasMultiplesOutputs && !tx.misunderstoodOutputs">
       <div class="background-content" copy-to-clipboard="{{ tx.outputs[0].addressToShow ? tx.outputs[0].addressToShow : tx.outputs[0].address }}">
         <img class="coin-img" *ngIf="tx.customData?.service != 'debitcard' && currencyProvider.COIN[tx.coin | uppercase]" src="assets/img/currencies/{{tx.coin}}.svg" [ngClass]="{'testnet': tx.network === 'testnet'}" alt="Coin" />
-        <img class="coin-img" *ngIf="tx.customData?.service != 'debitcard' && !currencyProvider.COIN[tx.coin | uppercase]" src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(tx.coin)}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'" [ngClass]="{'testnet': tx.network === 'testnet'}" alt="Coin" />
+        <img class="coin-img" *ngIf="tx.customData?.service != 'debitcard' && !currencyProvider.COIN[tx.coin | uppercase]" [src]="currencyProvider.getLogoURI(tx.coin)" [ngClass]="{'testnet': tx.network === 'testnet'}" alt="Coin" />
         <img *ngIf="tx.customData?.service == 'debitcard'" src="assets/img/icon-card.svg" class="debit-card">
 
         <span *ngIf="!tx.outputs[0].contactName">{{ tx.customData?.toWalletName || ((tx.outputs[0].addressToShow ? tx.outputs[0].addressToShow : tx.outputs[0].address) | shortenedAddress)}}</span>

--- a/src/pages/send/confirm/confirm.html
+++ b/src/pages/send/confirm/confirm.html
@@ -30,7 +30,7 @@
             <div class="background-content" *ngIf="!tx.paypro && !fromCoinbase" copy-to-clipboard="{{ tx.origToAddress }}">
               <img *ngIf="coin && currencyProvider.COIN[coin | uppercase]" class="coin-img" src="assets/img/currencies/{{tx.coin}}.svg" [ngClass]="{'testnet': tx.network === 'testnet'}" alt="Coin" />
               <ion-icon *ngIf="coin && !currencyProvider.COIN[coin | uppercase]" class="coin-img" [ngClass]="{'testnet': tx.network === 'testnet'}" item-start>
-                <img src="https://tokens.1inch.exchange/{{currencyProvider.getTokenAddress(coin)}}.png" onerror="this.onerror=null;this.src='assets/img/icon-swap.svg'" />
+                <img [src]="currencyProvider.getLogoURI(coin)"/>
               </ion-icon>
               <span *ngIf="!tx.name">{{toAddressName || (tx.origToAddress | shortenedAddress)}}</span>
               <span class="ellipsis" *ngIf="tx.name">{{tx.name}}</span>

--- a/src/pages/token-swap/token-swap-checkout/token-swap-checkout.ts
+++ b/src/pages/token-swap/token-swap-checkout/token-swap-checkout.ts
@@ -243,6 +243,7 @@ export class TokenSwapCheckoutPage {
         keyId: this.toWalletSelected.keyId,
         name: this.toToken.name,
         address: this.toToken.address,
+        logoURI: this.toToken.logoURI,
         symbol: this.toToken.symbol.toLowerCase(),
         decimals: this.toToken.decimals
       };

--- a/src/providers/currency/coin.ts
+++ b/src/providers/currency/coin.ts
@@ -5,6 +5,7 @@ export interface CoinOpts {
   name: string;
   chain: string;
   coin: string;
+  logoURI?: string;
   unitInfo?: {
     // Config/Precision
     unitName: string;

--- a/src/providers/currency/currency.ts
+++ b/src/providers/currency/currency.ts
@@ -83,6 +83,7 @@ export class CurrencyProvider {
       name: customToken.name,
       chain: 'ETH',
       coin: customToken.symbol,
+      logoURI: customToken.logoURI,
       unitInfo: {
         unitName: customToken.symbol.toUpperCase(),
         unitToSatoshi: 10 ** customToken.decimals,
@@ -142,6 +143,10 @@ export class CurrencyProvider {
     this.http.get(TokensListAPIUrl).subscribe((data: any) => {
       this.availableCustomTokens = Object.values(data.tokens) as Token[];
     });
+  }
+
+  getLogoURI(coin: string): string {
+    return this.coinOpts[coin].logoURI || 'assets/img/default-erc20.svg';
   }
 
   isUtxoCoin(coin: string): boolean {


### PR DESCRIPTION
```

address: "0xc581b735a1688071a1746c968e0798d642ede491"
decimals: 6
logoURI: "https://tokens.1inch.exchange/0xdac17f958d2ee523a2206206994597c13d831ec7.png"
name: "Euro Tether"
symbol: "EURT"
```
Sometimes contract address is not the same from the logo uri