### PR TITLE
Zero-Confirmation Escrows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2636,11 +2636,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
           "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-        },
-        "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
         }
       }
     },
@@ -6416,9 +6411,9 @@
       }
     },
     "bitcore-lib-cash": {
-      "version": "8.25.10",
-      "resolved": "https://registry.npmjs.org/bitcore-lib-cash/-/bitcore-lib-cash-8.25.10.tgz",
-      "integrity": "sha512-1fSY2oqUtYVe34nWYLsSy7us5n1hqkuOo1yo76fuv4lLhfADwjfyB332uA85btCajSMhXak6WZTty5pRDRfaQw==",
+      "version": "8.25.21",
+      "resolved": "https://registry.npmjs.org/bitcore-lib-cash/-/bitcore-lib-cash-8.25.21.tgz",
+      "integrity": "sha512-1AZ5YirhgbbYxfj8/5HuIo3wIybyheSxFC8l/T3R7P2CtMLv4cbrlSbKr5tAqAGYiEAyo7UCX6WC8tVgBxJU5g==",
       "requires": {
         "bitcore-lib": "^8.25.10",
         "bn.js": "=4.11.8",
@@ -6539,16 +6534,16 @@
       }
     },
     "bitcore-wallet-client": {
-      "version": "8.25.20",
-      "resolved": "https://registry.npmjs.org/bitcore-wallet-client/-/bitcore-wallet-client-8.25.20.tgz",
-      "integrity": "sha512-t+mQoiwIVKeXdDpvQpopa5sYTTeFW7/AVFgsuI5JwY1BlNjOgU5TAweGktU9jEWGSBBWhXhOSaqbTVqQcbna0w==",
+      "version": "8.25.21",
+      "resolved": "https://registry.npmjs.org/bitcore-wallet-client/-/bitcore-wallet-client-8.25.21.tgz",
+      "integrity": "sha512-f6+RVOreZa3GVputLb7f60LQlQa1YHVFSG3Tslg2Sb+C2EYq9fuplu8v/a4urAIjcf4C6TBpH/qBGvDXVVWAGw==",
       "requires": {
         "ajv": "^6.10.0",
         "async": "^0.9.0",
         "awesome-typescript-loader": "^5.2.1",
         "bip38": "^1.3.0",
         "bitcore-mnemonic": "^8.25.10",
-        "crypto-wallet-core": "^8.25.16",
+        "crypto-wallet-core": "^8.25.21",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.20",
         "preconditions": "^2.2.3",
@@ -8739,12 +8734,12 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "crypto-wallet-core": {
-      "version": "8.25.16",
-      "resolved": "https://registry.npmjs.org/crypto-wallet-core/-/crypto-wallet-core-8.25.16.tgz",
-      "integrity": "sha512-QR+Cyh4ogaP6gcQvW859V8rMFCQhSZr/Nk6MJQ8uumJGhxa9Jn/kriG/PndbchSHmxoCVfvM1oY+ulWw50T1Kg==",
+      "version": "8.25.21",
+      "resolved": "https://registry.npmjs.org/crypto-wallet-core/-/crypto-wallet-core-8.25.21.tgz",
+      "integrity": "sha512-0Bt3L++C8rXybsCY7jLj2na6GVqHrLBg3KbNxwIzKdo56Jaf0SSVgug0k8Iey5QtHeNy3/NKyPb3CG5SKjkJyw==",
       "requires": {
         "bitcore-lib": "^8.25.10",
-        "bitcore-lib-cash": "^8.25.10",
+        "bitcore-lib-cash": "^8.25.21",
         "bitcore-lib-doge": "^8.25.10",
         "bitcore-lib-ltc": "^8.25.14",
         "ethers": "^5.0.12",
@@ -10095,9 +10090,9 @@
       }
     },
     "ethers": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.6.tgz",
-      "integrity": "sha512-F7LXARyB/Px3AQC6/QKedWZ8eqCkgOLORqL4B/F0Mag/K+qJSFGqsR36EaOZ6fKg3ZonI+pdbhb4A8Knt/43jQ==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
+      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
       "requires": {
         "@ethersproject/abi": "5.4.1",
         "@ethersproject/abstract-provider": "5.4.1",
@@ -10105,7 +10100,7 @@
         "@ethersproject/address": "5.4.0",
         "@ethersproject/base64": "5.4.0",
         "@ethersproject/basex": "5.4.0",
-        "@ethersproject/bignumber": "5.4.1",
+        "@ethersproject/bignumber": "5.4.2",
         "@ethersproject/bytes": "5.4.0",
         "@ethersproject/constants": "5.4.0",
         "@ethersproject/contracts": "5.4.1",
@@ -10129,6 +10124,18 @@
         "@ethersproject/wallet": "5.4.0",
         "@ethersproject/web": "5.4.0",
         "@ethersproject/wordlists": "5.4.0"
+      },
+      "dependencies": {
+        "@ethersproject/bignumber": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
+          "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "bn.js": "^4.11.9"
+          }
+        }
       }
     },
     "ethjs-unit": {
@@ -10720,9 +10727,9 @@
       "dev": true
     },
     "fast-safe-stringify": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-      "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastq": {
       "version": "1.8.0",
@@ -11217,6 +11224,15 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "get-uri": {
@@ -13038,21 +13054,22 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -18107,9 +18124,9 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.172",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
-          "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
+          "version": "4.14.173",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
+          "integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg=="
         },
         "agent-base": {
           "version": "6.0.2",
@@ -23229,21 +23246,22 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -23456,9 +23474,9 @@
       }
     },
     "ws": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
     },
     "xcode": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "apple-wallet-ng": "1.1.1",
     "base64-js": "1.3.0",
     "bitauth": "git+https://github.com/bitpay/bitauth.git#68cf0353bf517a7e5293478608839fa904351eb6",
-    "bitcore-wallet-client": "8.25.20",
+    "bitcore-wallet-client": "8.25.21",
     "buffer-compare": "1.1.1",
     "chart.js": "2.9.4",
     "cordova": "9.0.0",

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -1111,7 +1111,9 @@ export class ConfirmPage {
             data: instruction.data,
             gasLimit: tx.gasLimit
           });
-          txp.instantAcceptanceEscrow = instruction.instantAcceptanceEscrow;
+          if (this.walletProvider.isZceCompatible(this.wallet)) {
+            txp.instantAcceptanceEscrow = instruction.instantAcceptanceEscrow;
+          }
         }
       } else {
         if (tx.fromSelectInputs) {
@@ -1831,9 +1833,7 @@ export class ConfirmPage {
       this.updateTx(this.tx, this.wallet, {
         clearCache: true,
         dryRun: true
-      }).catch(err => {
-        this.handleError(err);
-      });
+      }).catch(err => this.handleError(err));
       return;
     }
 

--- a/src/pages/send/confirm/confirm.ts
+++ b/src/pages/send/confirm/confirm.ts
@@ -1111,6 +1111,7 @@ export class ConfirmPage {
             data: instruction.data,
             gasLimit: tx.gasLimit
           });
+          txp.instantAcceptanceEscrow = instruction.instantAcceptanceEscrow;
         }
       } else {
         if (tx.fromSelectInputs) {
@@ -1824,6 +1825,17 @@ export class ConfirmPage {
       err instanceof this.errors.INSUFFICIENT_FUNDS_FOR_FEE;
     const isInsufficientLinkedEthFundsForFeeErr =
       err instanceof this.errors.INSUFFICIENT_ETH_FEE;
+
+    if (this.tx.paypro.instructions[0].instantAcceptanceEscrow) {
+      this.tx.paypro.instructions[0].instantAcceptanceEscrow = undefined;
+      this.updateTx(this.tx, this.wallet, {
+        clearCache: true,
+        dryRun: true
+      }).catch(err => {
+        this.handleError(err);
+      });
+      return;
+    }
 
     if (isInsufficientFundsErr) {
       if (this.showUseUnconfirmedMsg()) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -90,3 +90,4 @@ export { NewFeatureData } from '../providers/new-feature-data/new-feature-data';
 
 export { CardPhasesProvider } from '../providers/card-phases/card-phases';
 export { AbiDecoderProvider } from '../providers/abi-decoder/abi-decoder';
+export { ZceProvider } from '../providers/zce/zce';

--- a/src/providers/providers.module.ts
+++ b/src/providers/providers.module.ts
@@ -88,7 +88,8 @@ import {
   Vibration,
   WalletConnectProvider,
   WalletProvider,
-  WyreProvider
+  WyreProvider,
+  ZceProvider
 } from './index';
 
 @NgModule({
@@ -179,7 +180,8 @@ import {
     PersistenceProvider,
     File,
     CardPhasesProvider,
-    AbiDecoderProvider
+    AbiDecoderProvider,
+    ZceProvider
   ]
 })
 export class ProvidersModule {}

--- a/src/providers/wallet/mocks/wallet.mock.ts
+++ b/src/providers/wallet/mocks/wallet.mock.ts
@@ -124,6 +124,7 @@ export class WalletMock {
     network?: string;
     publicKeyRing?: any[];
     coin: string;
+    rootPath: string;
   };
   coin: string;
   id: string;
@@ -146,7 +147,8 @@ export class WalletMock {
       walletId: 'walletid1',
       walletName: 'Test wallet',
       keyId: 'keyId1',
-      coin: 'btc'
+      coin: 'btc',
+      rootPath: "m/44'/0'/0'"
     };
     this.coin = 'btc';
     this.id = 'walletid1';

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -1075,12 +1075,15 @@ export class WalletProvider {
 
   public removeEscrowReclaimTransactions(wallet, txs): any[] {
     if (!this.isZceCompatible(wallet)) return txs;
-    return txs.filter(tx =>
-      ['moved', 'moving'].includes(tx.action) &&
-      txs.find(tx2 => tx2.time === tx.time)
-        ? false
-        : true
-    );
+    return txs.filter(tx => {
+      if (tx.action !== 'moved') {
+        return true;
+      }
+      const sendTxAtSameTimeAsMove = txs.find(
+        tx2 => tx2.action === 'sent' && Math.abs(tx.time - tx2.time) < 100
+      );
+      return !sendTxAtSameTimeAsMove;
+    });
   }
 
   // Approx utxo amount, from which the uxto is economically redeemable

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -24,6 +24,7 @@ import { PopupProvider } from '../popup/popup';
 import { RateProvider } from '../rate/rate';
 import { TouchIdProvider } from '../touchid/touchid';
 import { TxFormatProvider } from '../tx-format/tx-format';
+import { ZceProvider } from '../zce/zce';
 
 export interface HistoryOptionsI {
   limitTx?: string;
@@ -89,6 +90,7 @@ export interface TransactionProposal {
   invoiceID?: string;
   multisigGnosisContractAddress?: string;
   multisigContractAddress?: string;
+  instantAcceptanceEscrow?: number;
   isTokenSwap?: boolean;
 }
 
@@ -135,7 +137,8 @@ export class WalletProvider {
     private keyProvider: KeyProvider,
     private platformProvider: PlatformProvider,
     private logsProvider: LogsProvider,
-    private appProvider: AppProvider
+    private appProvider: AppProvider,
+    private zceProvider: ZceProvider
   ) {
     this.logger.debug('WalletProvider initialized');
     this.isPopupOpen = false;
@@ -1267,13 +1270,10 @@ export class WalletProvider {
     return new Promise((resolve, reject) => {
       if (_.isEmpty(txp) || _.isEmpty(wallet))
         return reject('MISSING_PARAMETER');
-
       wallet.createTxProposal(txp, (err, createdTxp) => {
         if (err) return reject(err);
-        else {
-          this.logger.debug('Transaction created');
-          return resolve(createdTxp);
-        }
+        this.logger.debug('Transaction created');
+        return resolve(createdTxp);
       });
     });
   }
@@ -1297,7 +1297,12 @@ export class WalletProvider {
     });
   }
 
-  public signTx(wallet, txp, password: string): Promise<any> {
+  public signTx(
+    wallet,
+    txp,
+    password: string,
+    localOnly = false
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       if (!wallet || !txp) return reject('MISSING_PARAMETER');
 
@@ -1331,7 +1336,9 @@ export class WalletProvider {
           this.logsProvider.get(this.appProvider.info.nameCase, platform);
         });
       }
-
+      if (localOnly) {
+        return resolve({ ...txp, signatures });
+      }
       try {
         wallet.pushSignatures(txp, signatures, (err, signedTxp) => {
           if (err) {
@@ -1676,6 +1683,25 @@ export class WalletProvider {
     });
   }
 
+  private async generateEscrowReclaimTx(wallet, signedTxp, password) {
+    const reclaimTxp = this.zceProvider.generateEscrowReclaimTxp(
+      wallet,
+      signedTxp
+    );
+    const signedReclaimTxp = await this.signTx(
+      wallet,
+      reclaimTxp,
+      password,
+      true
+    );
+    const reclaimSignatureString = signedReclaimTxp.signatures[0];
+    return this.zceProvider.generateEscrowReclaimRawTx(
+      signedTxp,
+      reclaimTxp,
+      reclaimSignatureString
+    );
+  }
+
   private signAndBroadcast(wallet, publishedTxp, password): Promise<any> {
     return new Promise((resolve, reject) => {
       this.onGoingProcessProvider.set('signingTx');
@@ -1685,8 +1711,16 @@ export class WalletProvider {
         publishedTxp.amount -
         publishedTxp.fee;
       this.signTx(wallet, publishedTxp, password)
-        .then(signedTxp => {
+        .then(async signedTxp => {
           this.invalidateCache(wallet);
+          if (signedTxp.escrowAddress) {
+            const escrowReclaimTx = await this.generateEscrowReclaimTx(
+              wallet,
+              signedTxp,
+              password
+            );
+            signedTxp.escrowReclaimTx = escrowReclaimTx;
+          }
           if (signedTxp.status == 'accepted') {
             this.onGoingProcessProvider.set('broadcastingTx');
             this.broadcastTx(wallet, signedTxp)

--- a/src/providers/wallet/wallet.ts
+++ b/src/providers/wallet/wallet.ts
@@ -815,9 +815,13 @@ export class WalletProvider {
       this.getSavedTxs(walletId)
         .then(txsFromLocal => {
           fixTxsUnit(txsFromLocal);
-
-          const nonEscrowReclaimTxs = this.removeEscrowReclaimTransactions(wallet, txsFromLocal);
-          const confirmedTxs = this.removeAndMarkSoftConfirmedTx(nonEscrowReclaimTxs);
+          const nonEscrowReclaimTxs = this.removeEscrowReclaimTransactions(
+            wallet,
+            txsFromLocal
+          );
+          const confirmedTxs = this.removeAndMarkSoftConfirmedTx(
+            nonEscrowReclaimTxs
+          );
           const endingTxid = confirmedTxs[0] ? confirmedTxs[0].txid : null;
           const endingTs = confirmedTxs[0] ? confirmedTxs[0].time : null;
 
@@ -979,7 +983,10 @@ export class WalletProvider {
                   });
                   // Final update
                   if (walletId == wallet.credentials.walletId) {
-                    wallet.completeHistory = this.removeEscrowReclaimTransactions(wallet, newHistory);
+                    wallet.completeHistory = this.removeEscrowReclaimTransactions(
+                      wallet,
+                      newHistory
+                    );
                   }
 
                   return this.persistenceProvider
@@ -1067,9 +1074,12 @@ export class WalletProvider {
   }
 
   public removeEscrowReclaimTransactions(wallet, txs): any[] {
-    if(!this.isZceCompatible(wallet)) return txs;
-    return txs.filter(tx => 
-      ['moved', 'moving'].includes(tx.action) && txs.find(tx2 => tx2.time === tx.time) ? false : true
+    if (!this.isZceCompatible(wallet)) return txs;
+    return txs.filter(tx =>
+      ['moved', 'moving'].includes(tx.action) &&
+      txs.find(tx2 => tx2.time === tx.time)
+        ? false
+        : true
     );
   }
 
@@ -1692,7 +1702,14 @@ export class WalletProvider {
   }
 
   public isZceCompatible(wallet) {
-    return wallet.coin === 'bch' && wallet.credentials.addressType === 'P2PKH';
+    const isSingleSigBch =
+      wallet.coin === 'bch' && wallet.credentials.addressType === 'P2PKH';
+    const isNotDuplicatedFromAnotherChain =
+      wallet.credentials.rootPath.split('/')[2] === "145'";
+    return (
+      isSingleSigBch &&
+      (isNotDuplicatedFromAnotherChain || wallet.network === 'testnet')
+    );
   }
 
   private async generateEscrowReclaimTx(wallet, signedTxp, password) {

--- a/src/providers/zce/zce.ts
+++ b/src/providers/zce/zce.ts
@@ -1,0 +1,137 @@
+import { Injectable } from '@angular/core';
+
+import { BwcProvider } from '../bwc/bwc';
+
+@Injectable()
+export class ZceProvider {
+  private bwcUtils;
+  private bitcoreLibCash;
+  constructor(private bwcProvider: BwcProvider) {
+    this.bwcUtils = this.bwcProvider.getUtils();
+    this.bitcoreLibCash = this.bwcProvider.getBitcoreCash();
+  }
+
+  public generateEscrowReclaimTxp(wallet, signedTxp) {
+    const reclaimAddress = this.createReclaimAddress(
+      wallet,
+      signedTxp.escrowAddress.path
+    );
+    const minFeeRate = signedTxp.feePerKb / 1000;
+    const zceTx = new this.bitcoreLibCash.Transaction(signedTxp.raw);
+    const outputIndex = this.getEscrowOutputIndex(
+      zceTx,
+      signedTxp.escrowAddress
+    );
+    const escrowSatoshis = zceTx.outputs[outputIndex].satoshis;
+    const reclaimTxSize = getEscrowReclaimTxSize(signedTxp.inputs.length);
+    const reclaimTxFee = minFeeRate * reclaimTxSize;
+    const outputAmount = escrowSatoshis - reclaimTxFee;
+    const reclaimTxp = {
+      addressType: 'P2PKH',
+      changeAddress: reclaimAddress,
+      coin: 'bch',
+      dryRun: false,
+      excludeUnconfirmedUtxos: false,
+      fee: reclaimTxFee,
+      from: signedTxp.escrowAddress.address,
+      inputs: [
+        {
+          address: signedTxp.escrowAddress.address,
+          satoshis: escrowSatoshis,
+          txid: signedTxp.txid,
+          vout: outputIndex,
+          path: signedTxp.escrowAddress.path,
+          publicKeys: signedTxp.escrowAddress.publicKeys
+        }
+      ],
+      outputs: [
+        {
+          toAddress: reclaimAddress.address,
+          amount: outputAmount,
+          message: null
+        }
+      ],
+      signingMethod: 'schnorr'
+    };
+    return reclaimTxp;
+  }
+
+  public generateEscrowReclaimRawTx(
+    signedTxp,
+    reclaimTxp,
+    reclaimSignatureSring
+  ) {
+    const t = this.bwcUtils.buildTx(reclaimTxp);
+    const signature = this.bitcoreLibCash.crypto.Signature.fromString(
+      reclaimSignatureSring
+    );
+    const transactionSignature = this.bitcoreLibCash.Transaction.Signature({
+      publicKey: signedTxp.escrowAddress.publicKeys[0],
+      prevTxId: signedTxp.txid,
+      outputIndex: 0,
+      inputIndex: 0,
+      signature,
+      sigtype: 0x41
+    });
+    t.applySignature(transactionSignature, 'schnorr');
+    return t.serialize();
+  }
+
+  private createReclaimAddress(wallet, escrowAddressPath) {
+    const reclaimAddressPath = getReclaimAddressPath(escrowAddressPath);
+    const reclaimAddress = this.bwcUtils.deriveAddress(
+      wallet.credentials.addressType,
+      wallet.credentials.publicKeyRing,
+      reclaimAddressPath,
+      wallet.credentials.m,
+      wallet.network,
+      wallet.coin
+    );
+    wallet.createAddress({ isChange: true }, () => {});
+    return reclaimAddress;
+  }
+
+  private getEscrowOutputIndex(zceTx, escrowAddress) {
+    const outputAddresses = zceTx.outputs.map(output =>
+      output.script.toAddress(escrowAddress.network).toString().split(':').pop()
+    );
+    return outputAddresses.indexOf(escrowAddress.address);
+  }
+}
+
+function getReclaimAddressPath(escrowAddressPath) {
+  const escrowAddressIndex = parseInt(
+    escrowAddressPath.split('/').slice(2)[0],
+    10
+  );
+  const reclaimAddressIndex = escrowAddressIndex + 1;
+  const reclaimAddressPath = escrowAddressPath
+    .split('/')
+    .slice(0, 2)
+    .concat([reclaimAddressIndex.toString()])
+    .join('/');
+  return reclaimAddressPath;
+}
+
+function getEscrowReclaimTxSize(numInputs) {
+  const baseSize = 186;
+  const baseRedeemScriptSize = 39;
+
+  const merkleValidationScriptSize = numInputs => {
+    const numLevels = Math.ceil(Math.log2(numInputs));
+    const opPickIndexBytes = numLevels < 17 ? 1 : 2;
+    const baseMerkleInputValidationSize = 24 + opPickIndexBytes;
+    const additionalBytesPerLevel = 7;
+    return baseMerkleInputValidationSize + additionalBytesPerLevel * numLevels;
+  };
+
+  const inputValidationScriptSize =
+    numInputs === 1 ? 24 : merkleValidationScriptSize(numInputs);
+  const redeemScriptSize = baseRedeemScriptSize + inputValidationScriptSize;
+
+  const pushDataBytes =
+    redeemScriptSize < 76 ? 0 : redeemScriptSize < 256 ? 1 : 2;
+
+  const txSize = baseSize + redeemScriptSize + pushDataBytes;
+  return txSize;
+}


### PR DESCRIPTION
This PR enables BitPay Wallet to make ZCE-secured payments to [JSON Payment Protocol](https://github.com/bitpay/jsonPaymentProtocol/blob/master/v2/specification.md) accepting merchants and requires `Bitcore Wallet Service` to be running the following Bitcore PR: https://github.com/bitpay/bitcore/pull/3240. `Bitcore Wallet Client` and `Bitcore Lib Cash` must also be upgraded to the commit in the aforementioned Bitcore PR, which can be done by pulling the Bitcore PR and using `npm link`.

**ZCEs enable instant, incentive-secure payments on Bitcoin Cash.** ZCE-secured payments can be accepted by merchants immediately upon receipt (without the need for a 5-10 second delay to monitor the network for double-spends) and with the same finality as a 1-confirmation transaction.

### Testing a ZCE-secured payment end-to-end

1. Clone the `bitcore` repo and pull the `zero-conf-escrows` branch from this PR: https://github.com/bitpay/bitcore/pull/3240
2. Start an instance of `Bitcore Wallet Service` locally using the branch above
3. Navigate to the `packages/bitcore-wallet-client` directory, and run `npm link`
4. Navigate to the `packages/bitcore-lib-cash` directory, and run `npm link`
5. Clone this repository (`wallet`), and pull this PR
6. Run `npm link bitcore-wallet-client && npm link bitcore-lib-cash` inside the `wallet` directory
7.  Run `npm start`
8. Create a testnet BCH Wallet, and in advanced settings, change the `Wallet Service URL` to `http://localhost:3232/bws/api`
9. Send at least $2.10 of testnet BCH to your newly created wallet
10. Create a $1 invoice on https://test.bitpay.com
11. Pay the invoice with your testnet BCH wallet

If everything is working properly, you'll see that the payment is instantly accepted by payment protocol. On the other hand, if you don't have at least 2x the invoice amount in your wallet, the broadcast step will _not_ be instant and will instead take ~8 seconds.