### PR TITLE
Fix fluctuating home balance

### DIFF
--- a/src/pages/tabs/tabs.ts
+++ b/src/pages/tabs/tabs.ts
@@ -366,7 +366,9 @@ export class TabsPage {
     opts.backedUp = true;
     let wallets = this.profileProvider.getWallets(opts);
     if (_.isEmpty(wallets)) {
-      this.events.publish('Local/HomeBalance');
+      if (!opts.coin) {
+        this.events.publish('Local/HomeBalance');
+      }
       return;
     }
 

--- a/src/pages/tabs/tabs.ts
+++ b/src/pages/tabs/tabs.ts
@@ -385,7 +385,7 @@ export class TabsPage {
     });
 
     Promise.all(promises).then(() => {
-      if (!this.hasConnectionError) {
+      if (!this.hasConnectionError && !opts.coin) {
         this.updateTotalBalance(wallets);
       }
       this.updateTxps();


### PR DESCRIPTION
Incoming blocks are currently triggering an "update home balance" calculation, but this calculation only includes wallets that match the currency of the incoming block (resulting in an incorrect total balance shown on the home tab). This PR prevents incorrect home balance calculations by ensuring that the home balance only updates when all wallets (of all currencies) are included in the total balance calculation.