### PR TITLE
[FIX] keep card IAB alive if analytics fails

### DIFF
--- a/src/providers/in-app-browser/in-app-browser.ts
+++ b/src/providers/in-app-browser/in-app-browser.ts
@@ -69,38 +69,50 @@ export class InAppBrowserProvider {
         }
       };
       ref.addEventListener('loadstop', initCb);
-      ref.addEventListener('loaderror', (err: InAppBrowserEvent & { sslerror?: number }) => {
-        // Don't prevent IAB from opening when encountering specific analytics errors
-        const analyticsWhitelist = [
-          `https://www.googletagmanager.com/gtag/js`,
-          `https://px.ads.linkedin.com/collect/`
-        ];
-        const urlWithoutParams = (err.url || '').split('?')[0].split('#')[0];
-        const isUntrustedCaError = err.code === 0 && err.sslerror === 3 && err.message === `The certificate authority is not trusted`;
-        const isUrlWhitelisted = analyticsWhitelist.includes(urlWithoutParams);
+      ref.addEventListener(
+        'loaderror',
+        (err: InAppBrowserEvent & { sslerror?: number }) => {
+          // Don't prevent IAB from opening when encountering specific analytics errors
+          const analyticsWhitelist = [
+            `https://www.googletagmanager.com/gtag/js`,
+            `https://px.ads.linkedin.com/collect/`
+          ];
+          const urlWithoutParams = (err.url || '').split('?')[0].split('#')[0];
+          const isUntrustedCaError =
+            err.code === 0 &&
+            err.sslerror === 3 &&
+            err.message === `The certificate authority is not trusted`;
+          const isUrlWhitelisted = analyticsWhitelist.includes(
+            urlWithoutParams
+          );
 
-        if (isUntrustedCaError && isUrlWhitelisted) {
-          this.logger.debug(`InAppBrowserProvider -> ${refName} encountered an untrusted CA loaderror for ${err.url}`);
-          return;
+          if (isUntrustedCaError && isUrlWhitelisted) {
+            this.logger.debug(
+              `InAppBrowserProvider -> ${refName} encountered an untrusted CA loaderror for ${err.url}`
+            );
+            return;
+          }
+
+          this.logger.debug(
+            `InAppBrowserProvider -> ${refName} ${JSON.stringify(
+              err
+            )} load error`
+          );
+          ref.error = true;
+          ref.show = () => {
+            this.actionSheetProvider
+              .createInfoSheet('default-error', {
+                msg: this.translate.instant(
+                  'Uh oh something went wrong! Please try again later.'
+                ),
+                title: this.translate.instant('Error')
+              })
+              .present();
+          };
+          this.onGoingProcess.clear();
+          rej();
         }
-
-        this.logger.debug(
-          `InAppBrowserProvider -> ${refName} ${JSON.stringify(err)} load error`
-        );
-        ref.error = true;
-        ref.show = () => {
-          this.actionSheetProvider
-            .createInfoSheet('default-error', {
-              msg: this.translate.instant(
-                'Uh oh something went wrong! Please try again later.'
-              ),
-              title: this.translate.instant('Error')
-            })
-            .present();
-        };
-        this.onGoingProcess.clear();
-        rej();
-      });
+      );
 
       ref.events$ = new Subject<Event>();
 


### PR DESCRIPTION
Usually when the IAB emits a loaderror, we disable the IAB. Certain devices occasionally receive untrusted CA loaderrors for non-essential analytics URLs like this:  
```
{
  "type": "loaderror",
  "url": "https://px.ads.linkedin.com/collect/?time=12345&pid=12345&url=https%3A%2F%2Fbitpay.com%2Fwallet-card%2Fget-started&pageUrl=https%3A%2F%2Fbitpay.com%2Fwallet-card%2Fget-started&ref=&fmt=js&s=1",
  "code": 0,
  "sslerror": 3,
  "message": "The certificate authority is not trusted"
}
```

As a workaround I've added a whitelist to prevent the IAB from being disabled for known problematic URLs so those users can still access the card feature:
`['https://www.googletagmanager.com/gtag/js', 'https://px.ads.linkedin.com/collect/']`