### PR TITLE
Fix: Prevent undefined decimals or infinite amounts for Tokens

### DIFF
--- a/src/pages/add/custom-token/custom-token.ts
+++ b/src/pages/add/custom-token/custom-token.ts
@@ -76,11 +76,16 @@ export class CustomTokenPage {
     this.tokenSearchResults = this.filteredTokens;
     this.TOKEN_SHOW_LIMIT = 10;
     this.currentTokenListPage = 0;
+    const bitpaySupportedTokens: string[] = this.currencyProvider
+      .getBitpaySupportedTokens()
+      .map(token => token.symbol.toLowerCase());
     this.availableCustomTokens = _.orderBy(
       this.currencyProvider.getAvailableCustomTokens(),
       'name'
     ).filter(token => {
-      return token.symbol.toLowerCase() != 'eth';
+      return !['eth', ...bitpaySupportedTokens].includes(
+        token.symbol.toLowerCase()
+      );
     });
     this.updateSearchInput('');
     this.showInvoiceWarning();

--- a/src/pages/coin-and-wallet-selector/coin-and-wallet-selector.ts
+++ b/src/pages/coin-and-wallet-selector/coin-and-wallet-selector.ts
@@ -283,21 +283,26 @@ export class CoinAndWalletSelectorPage {
         });
 
       if (_token.length > 0) token = _token[0];
+
+      if (!token.decimals)
+        return Promise.reject('Cannot create token wallet. Missing decimals');
+
+      const customToken = {
+        keyId: pairedWallet.keyId,
+        name: token.name,
+        address: token.address,
+        logoURI: token.logoURI,
+        symbol: token.symbol.toLowerCase(),
+        decimals: token.decimals
+      };
+
+      return this.profileProvider.createCustomTokenWallet(
+        pairedWallet,
+        customToken
+      );
+    } else {
+      return this.profileProvider.createTokenWallet(pairedWallet, token);
     }
-
-    const customToken = {
-      keyId: pairedWallet.keyId,
-      name: token.name,
-      address: token.address,
-      logoURI: token.logoURI,
-      symbol: token.symbol.toLowerCase(),
-      decimals: token.decimals
-    };
-
-    return this.profileProvider.createCustomTokenWallet(
-      pairedWallet,
-      customToken
-    );
   }
 
   public showTokensSearch() {

--- a/src/pages/exchange-crypto/exchange-crypto.ts
+++ b/src/pages/exchange-crypto/exchange-crypto.ts
@@ -517,12 +517,17 @@ export class ExchangeCryptoPage {
       supportedCoins.splice(index, 1);
     }
 
+    const bitpaySupportedTokens: string[] = this.currencyProvider
+      .getBitpaySupportedTokens()
+      .map(token => token.symbol.toLowerCase());
+
     const oneInchAllSupportedCoins = this.oneInchAllSupportedCoins.filter(
       token => {
-        return (
-          token.symbol.toLowerCase() != this.fromWalletSelected.coin &&
-          token.symbol.toLowerCase() != 'eth'
-        );
+        return ![
+          'eth',
+          this.fromWalletSelected.coin,
+          ...bitpaySupportedTokens
+        ].includes(token.symbol.toLowerCase());
       }
     );
 

--- a/src/pages/send/amount/amount.ts
+++ b/src/pages/send/amount/amount.ts
@@ -352,15 +352,26 @@ export class AmountPage {
   }
 
   public sendMax(): void {
+    this.logger.debug('SendMax init');
     this.useSendMax = true;
     this.allowSend = true;
     if (!this.wallet) {
       return this.finish();
     }
+    if (
+      this.wallet.cachedStatus &&
+      this.wallet.cachedStatus.availableBalanceSat
+    )
+      this.logger.debug(
+        `availableBalanceSat: ${this.wallet.cachedStatus.availableBalanceSat}`
+      );
+
     const maxAmount = this.txFormatProvider.satToUnit(
       this.wallet.cachedStatus.availableBalanceSat,
       this.wallet.coin
     );
+    this.logger.debug(`maxAmount setted with: ${maxAmount}`);
+
     this.zone.run(() => {
       this.expression = this.availableUnits[this.unitIndex].isFiat
         ? this.toFiat(maxAmount, this.wallet.coin).toFixed(2)

--- a/src/pages/token-swap/token-swap-checkout/token-swap-checkout.ts
+++ b/src/pages/token-swap/token-swap-checkout/token-swap-checkout.ts
@@ -250,19 +250,20 @@ export class TokenSwapCheckoutPage {
   }
 
   private createAndBindTokenWallet() {
+    if (_.isEmpty(this.toWalletSelected) || _.isEmpty(this.toToken)) return;
+    const tokenSymbol = this.toToken.symbol.toLowerCase();
     if (
-      !_.isEmpty(this.toWalletSelected) &&
-      !_.isEmpty(this.toToken) &&
-      this.toToken.symbol.toLowerCase() != 'eth' &&
+      tokenSymbol != 'eth' &&
       this.toWalletSelected.coin == 'eth' &&
-      this.toToken.symbol.toLowerCase() != this.toWalletSelected.coin
+      tokenSymbol != this.toWalletSelected.coin &&
+      this.currencyProvider.isCustomERCToken(tokenSymbol)
     ) {
       const customToken = {
         keyId: this.toWalletSelected.keyId,
         name: this.toToken.name,
         address: this.toToken.address,
         logoURI: this.toToken.logoURI,
-        symbol: this.toToken.symbol.toLowerCase(),
+        symbol: tokenSymbol,
         decimals: this.toToken.decimals
       };
 


### PR DESCRIPTION
The error is given by the following:
We were allowing to create tokens already supported by bitpay as "Custom tokens". (USDC, DAI, ...)
There was an error in the creation of tokens when selecting a previously supported one (such as USDC) from the crypto swap feature. A confusion between the attribute ''decimal" and "decimals".
It is something rare, so there were few users reporting the error.
As a consequence, a "USDC Custom token" was saved with undefined decimals, so unitToSatoshi was undefined and when wanting to make calculations it resulted in infinite amounts.


Solution:

I have removed the tokens already supported by Bitpay from the list of custom tokens. Since they can be added on previous pages.

The data of the tokens already supported will have priority over those of the custom tokens (To prevent them from continuing to use undefined decimal places and causing errors when sending funds)

Fixed the use of the function "createToken" and "createCustomToken"