### PR TITLE
Fix: Changelly supported chains for swaps

### DIFF
--- a/src/pages/exchange-crypto/exchange-crypto.ts
+++ b/src/pages/exchange-crypto/exchange-crypto.ts
@@ -330,8 +330,17 @@ export class ExchangeCryptoPage {
             _.isArray(promise.data.result) &&
             promise.data.result.length > 0
           ) {
+            const availableChains: string[] = this.currencyProvider.getAvailableChains();
             const supportedCoinsWithFixRateEnabled = promise.data.result
-              .filter(coin => coin.enabled && coin.fixRateEnabled)
+              .filter(
+                coin =>
+                  coin.enabled &&
+                  coin.fixRateEnabled &&
+                  coin.protocol &&
+                  [...availableChains, 'erc20'].includes(
+                    coin.protocol.toLowerCase()
+                  )
+              )
               .map(({ name }) => name);
 
             // TODO: add support to float-rate coins supported by Changelly


### PR DESCRIPTION
This PR solves the case in which tokens with the same currency abbreviation, but from a different chain than ERC20 are marked as supported, giving an error when obtaining the Changelly's rates for a certain pair, for example USDT